### PR TITLE
Support for detecting the sort of input we've been given

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,6 +12,10 @@ Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.1.1
 URL: https://github.com/mrc-ide/odin2
 BugReports: https://github.com/mrc-ide/odin2/issues
+Imports:
+    cli,
+    rlang
 Suggests:
-    testthat (>= 3.0.0)
+    testthat (>= 3.0.0),
+    withr
 Config/testthat/edition: 3

--- a/R/parse.R
+++ b/R/parse.R
@@ -1,0 +1,5 @@
+odin_parse <- function(expr, input = NULL) {
+  call <- environment()
+  dat <- parse_prepare(rlang::enquo(expr), input, call)
+  NULL
+}

--- a/R/parse.R
+++ b/R/parse.R
@@ -1,5 +1,5 @@
-odin_parse <- function(expr, input = NULL) {
+odin_parse <- function(expr, input_type = NULL) {
   call <- environment()
-  dat <- parse_prepare(rlang::enquo(expr), input, call)
+  dat <- parse_prepare(rlang::enquo(expr), input_type, call)
   NULL
 }

--- a/R/parse_prepare.R
+++ b/R/parse_prepare.R
@@ -1,0 +1,115 @@
+parse_prepare <- function(quo, input, call) {
+  info <- parse_prepare_detect(quo, input, call)
+  filename <- NULL
+
+  if (info$type == "expression") {
+    src <- NULL
+    if (rlang::is_call(info$value, "quote")) {
+      cli::cli_abort(
+        "You have an extra layer of 'quote()' around 'expr'",
+        arg = "expr", call = call)
+    }
+    if (!rlang::is_call(info$value, "{")) {
+      cli::cli_abort(
+        "Expected 'expr' to be a multiline expression within curly braces",
+        arg = "expr", call = call)
+    }
+    exprs <- lapply(as.list(info$value[-1]), function(x) list(value = x))
+  } else {
+    if (info$type == "file") {
+      filename <- info$value
+      exprs <- parse(file = filename, keep.source = TRUE)
+    } else {
+      str <- paste(info$value, collapse = "\n")
+      exprs <- parse(text = str, keep.source = TRUE)
+    }
+    start <- utils::getSrcLocation(exprs, "line", first = TRUE)
+    end <- utils::getSrcLocation(exprs, "line", first = FALSE)
+    src_ref <- as.character(attr(exprs, "wholeSrcref", exact = TRUE))
+    src_str <- vcapply(seq_along(exprs), function(i) {
+      paste(src_ref[start[[i]]:end[[i]]], collapse = "\n")
+    })
+    exprs <- Map(list,
+                 value = as.list(exprs),
+                 start = start,
+                 end = end,
+                 str = src_str)
+  }
+
+  list(type = info$type,
+       filename = filename,
+       exprs = exprs)
+}
+
+
+parse_prepare_detect <- function(quo, input, call) {
+  expr <- rlang::quo_get_expr(quo)
+  envir <- rlang::quo_get_env(quo)
+
+  ## First, resolve and redirection via symbols:
+  if (rlang::is_symbol(expr)) {
+    sym <- rlang::as_name(expr)
+    if (!rlang::env_has(envir, sym, inherit = TRUE)) {
+      cli::cli_abort("Could not find expression '{sym}'",
+                     arg = "expr", call = call)
+    }
+    expr <- rlang::env_get(envir, sym, inherit = TRUE)
+  }
+
+  if (!is.null(input)) {
+    input <- match_value(input, c("file", "text", "expression"))
+  }
+
+  if (is.language(expr)) {
+    if (!is.null(input) && input != "expression") {
+      cli::cli_abort(
+        c("Invalid input for odin; given expression but expected {input}",
+          i = "You have requested '{input}' only via the 'input' argument"),
+        arg = "expr", call = call)
+    }
+    input <- "expression"
+  } else if (is.character(expr)) {
+    if (is.null(input)) {
+      if (length(expr) != 1 || grepl("([\n;=]|<-)", expr)) {
+        input <- "text"
+      } else if (file.exists(expr)) {
+        input <- "file"
+      } else {
+        cli::cli_abort(
+          "'{expr}' looks like a filename but does not exist",
+          arg = "expr", call = call)
+      }
+    } else if (input == "expression") {
+      cli::cli_abort(
+        c("Invalid input for odin; given string but expected {input}",
+          i = "You have requested '{input}' only via the 'input' argument"),
+        arg = "expr", call = call)
+    } else if (input == "file") {
+      if (length(expr) != 1) {
+        cli::cli_abort(
+          c("Invalid input for odin; expected a scalar for 'expr'",
+            i = paste("You have requested 'input = \"file\" but provided",
+                      "'expr' with length {length(expr)}")),
+          arg = "expr", call = call)
+      }
+      ## TODO: check for length and containing newlines
+      if (!file.exists(expr)) {
+        cli::cli_abort("File '{expr}' does not exist",
+                       arg = "expr", call = call)
+      }
+    }
+  } else {
+    if (is.null(input)) {
+      expected <- "a string, character vector or expression"
+    } else if (input == "expression") {
+      expected <- "an expression"
+    } else if (input == "file") {
+      expected <- "a string"
+    } else if (input == "text") {
+      expected <- "a string or character vector"
+    }
+    cli::cli_abort("Invalid input for odin; expected {expected}",
+                   arg = "expr", call = call)
+  }
+  list(type = input, value = expr)
+}

--- a/R/util.R
+++ b/R/util.R
@@ -1,3 +1,26 @@
 `%||%` <- function(x, y) { # nolint
   if (is.null(x)) y else x
 }
+
+
+squote <- function(x) {
+  sprintf("'%s'", x)
+}
+
+
+vcapply <- function(...) {
+  vapply(..., FUN.VALUE = "")
+}
+
+
+match_value <- function(x, choices, name = deparse(substitute(x)), arg = name,
+                        call = NULL) {
+  assert_scalar_character(x, call = call, arg = arg)
+  if (!(x %in% choices)) {
+    choices_str <- paste(squote(choices), collapse = ", ")
+    cli::cli_abort(c("'{name}' must be one of {choices_str}",
+                     i = "Instead we were given '{x}'"), call = call,
+                   arg = arg)
+  }
+  x
+}

--- a/R/util_assert.R
+++ b/R/util_assert.R
@@ -1,0 +1,44 @@
+assert_scalar <- function(x, name = deparse(substitute(x)), arg = name,
+                          call = NULL)  {
+  if (length(x) != 1) {
+    cli::cli_abort(
+      c("'{name}' must be a scalar",
+        i = "{name} has length {length(x)}"),
+      call = call, arg = arg)
+  }
+  invisible(x)
+}
+
+
+assert_character <- function(x, name = deparse(substitute(x)),
+                             arg = name, call = NULL) {
+  if (!is.character(x)) {
+    cli::cli_abort("Expected '{name}' to be character", call = call, arg = arg)
+  }
+  invisible(x)
+}
+
+
+assert_logical <- function(x, name = deparse(substitute(x)),
+                          arg = name, call = NULL) {
+  if (!is.logical(x)) {
+    cli::cli_abort("Expected '{name}' to be logical", arg = arg, call = call)
+  }
+  invisible(x)
+}
+
+assert_nonmissing <- function(x, name = deparse(substitute(x)),
+                          arg = name, call = NULL) {
+  if (anyNA(x)) {
+    cli::cli_abort("Expected '{name}' to be non-NA", arg = arg, call = call)
+  }
+  invisible(x)
+}
+
+
+assert_scalar_character <- function(x, name = deparse(substitute(x)),
+                                  arg = name, call = NULL) {
+  assert_scalar(x, name, arg = arg, call = call)
+  assert_character(x, name, arg = arg, call = call)
+  assert_nonmissing(x, name, arg = arg, call = call)
+}

--- a/odin2.Rproj
+++ b/odin2.Rproj
@@ -1,0 +1,17 @@
+Version: 1.0
+
+RestoreWorkspace: Default
+SaveWorkspace: Default
+AlwaysSaveHistory: Default
+
+EnableCodeIndexing: Yes
+UseSpacesForTab: Yes
+NumSpacesForTab: 2
+Encoding: UTF-8
+
+RnwWeave: Sweave
+LaTeX: pdfLaTeX
+
+BuildType: Package
+PackageUseDevtools: Yes
+PackageInstallArgs: --no-multiarch --with-keep.source

--- a/tests/testthat/test-parse-prepare.R
+++ b/tests/testthat/test-parse-prepare.R
@@ -1,0 +1,182 @@
+test_that("can detect expression as an expression", {
+  expr <- quote({a <- 1})
+  quo <- rlang::new_quosure(expr)
+  expect_equal(
+    parse_prepare_detect(quo, NULL, NULL),
+    list(type = "expression",
+         value = expr))
+  expect_equal(
+    parse_prepare_detect(quo, "expression", NULL),
+    parse_prepare_detect(quo, NULL, NULL))
+})
+
+
+test_that("can detect a path as a filename", {
+  path <- withr::local_tempfile()
+  quo <- rlang::new_quosure(path)
+  writeLines("a <- 1", path)
+  expect_equal(parse_prepare_detect(quo, NULL, NULL),
+               list(type = "file", value = path))
+  expect_equal(parse_prepare_detect(quo, "file", NULL),
+               parse_prepare_detect(quo, NULL, NULL))
+})
+
+
+test_that("can detect code as a string", {
+  code <- "a <- 1\nb <- 2"
+  expect_equal(
+    parse_prepare_detect(rlang::new_quosure(code), NULL, NULL),
+    list(type = "text", value = code))
+})
+
+
+test_that("can detect code as a character vector", {
+  code <- c("a <- 1", "b <- 2")
+  expect_equal(
+    parse_prepare_detect(rlang::new_quosure(code), NULL, NULL),
+    list(type = "text", value = code))
+})
+
+
+test_that("throw error on unclassifiable input", {
+  expect_error(
+    parse_prepare_detect(rlang::new_quosure(NULL), NULL, NULL),
+    "Invalid input for odin; expected a string, character vector or")
+  expect_error(
+    parse_prepare_detect(rlang::new_quosure(TRUE), NULL, NULL),
+    "Invalid input for odin; expected a string, character vector or")
+})
+
+
+test_that("sensible error if requiring expression but given other type", {
+  expect_error(
+    parse_prepare_detect(rlang::new_quosure("a <- 1"), "expression", NULL),
+    "Invalid input for odin; given string but expected expression")
+  expect_error(
+    parse_prepare_detect(rlang::new_quosure(NULL), "expression", NULL),
+    "Invalid input for odin; expected an expression")
+})
+
+
+test_that("sensible error if requiring a file but given other type", {
+  expect_error(
+    parse_prepare_detect(rlang::new_quosure(quote({a <- 1})), "file", NULL),
+    "Invalid input for odin; given expression but expected file")
+  expect_error(
+    parse_prepare_detect(rlang::new_quosure(NULL), "file", NULL),
+    "Invalid input for odin; expected a string")
+})
+
+
+test_that("sensible error if requiring a file but the file does not exist", {
+  quo <- rlang::new_quosure("somepath.R")
+  expect_error(
+    parse_prepare_detect(quo, "file", NULL),
+    "File 'somepath.R' does not exist")
+})
+
+
+test_that("sensible error if file argument is invalid", {
+  expect_error(
+    parse_prepare_detect(rlang::new_quosure(character()), "file", NULL),
+    "Invalid input for odin; expected a scalar for 'expr'")
+  expect_error(
+    parse_prepare_detect(rlang::new_quosure(letters), "file", NULL),
+    "Invalid input for odin; expected a scalar for 'expr'")
+})
+
+
+test_that("sensible error if given a non-existant file-like string", {
+  expect_error(
+    parse_prepare_detect(rlang::new_quosure("foo.R"), NULL, NULL),
+    "'foo.R' looks like a filename but does not exist")
+})
+
+
+test_that("sensible error if requiring text but given other type", {
+  expect_error(
+    parse_prepare_detect(rlang::new_quosure(quote({a <- 1})), "text", NULL),
+    "Invalid input for odin; given expression but expected text")
+  expect_error(
+    parse_prepare_detect(rlang::new_quosure(NULL), "text", NULL),
+    "Invalid input for odin; expected a string or character vector")
+})
+
+
+test_that("redirect through symbols", {
+  a <- "a <- 1\nb <- 2"
+  expect_equal(
+    parse_prepare_detect(rlang::new_quosure(quote(a)), "text", NULL),
+    list(type = "text",
+         value = a))
+  expect_error(
+    parse_prepare_detect(rlang::new_quosure(quote(asdfa)), "text", NULL),
+    "Could not find expression 'asdfa'")
+})
+
+
+test_that("can load code from an expression", {
+  quo <- rlang::new_quosure(quote({
+    a <- 1
+    b <- 2
+  }))
+  expect_equal(
+    parse_prepare(quo, NULL, NULL),
+    list(type = "expression",
+         filename = NULL,
+         exprs = list(list(value = quote(a <- 1)),
+                      list(value = quote(b <- 2)))))
+})
+
+
+test_that("fail if an extra level of quoting is present", {
+  quo <- rlang::new_quosure(quote(quote({a <- 1})))
+  expect_error(
+    parse_prepare(quo, NULL, NULL),
+    "You have an extra layer of 'quote()' around 'expr'",
+    fixed = TRUE)
+})
+
+
+test_that("require that expr is multiline", {
+  quo <- rlang::new_quosure(quote(a <- 1))
+  expect_error(
+    parse_prepare(quo, NULL, NULL),
+    "Expected 'expr' to be a multiline expression within curly braces",
+    fixed = TRUE)
+})
+
+
+test_that("can read expressions from file", {
+  path <- withr::local_tempfile()
+  writeLines(c("a <- 1", "b <- 2"), path)
+  expect_equal(
+    parse_prepare(rlang::new_quosure(path), "file", NULL),
+    list(type = "file",
+         filename = path,
+         exprs = list(list(value = quote(a <- 1),
+                           start = 1,
+                           end = 1,
+                           str = "a <- 1"),
+                      list(value = quote(b <- 2),
+                           start = 2,
+                           end = 2,
+                           str = "b <- 2"))))
+})
+
+
+test_that("can read expressions from file", {
+  code <- c("a <- 1", "b <- 2")
+  expect_equal(
+    parse_prepare(rlang::new_quosure(code), "text", NULL),
+    list(type = "text",
+         filename = NULL,
+         exprs = list(list(value = quote(a <- 1),
+                           start = 1,
+                           end = 1,
+                           str = "a <- 1"),
+                      list(value = quote(b <- 2),
+                           start = 2,
+                           end = 2,
+                           str = "b <- 2"))))
+})

--- a/tests/testthat/test-parse.R
+++ b/tests/testthat/test-parse.R
@@ -1,0 +1,7 @@
+test_that("can parse trivial system", {
+  res <- odin_parse({
+    initial(x) <- 0
+    update(x) <- 0
+  })
+  expect_null(res)
+})

--- a/tests/testthat/test-util-assert.R
+++ b/tests/testthat/test-util-assert.R
@@ -1,0 +1,25 @@
+test_that("assert_scalar", {
+  expect_error(assert_scalar(NULL), "must be a scalar")
+  expect_error(assert_scalar(numeric(0)), "must be a scalar")
+  expect_error(assert_scalar(1:2), "must be a scalar")
+})
+
+
+test_that("assert_character", {
+  expect_silent(assert_character("a"))
+  expect_error(assert_character(1), "Expected '.+' to be character")
+  expect_error(assert_character(TRUE), "Expected '.+' to be character")
+})
+
+
+test_that("assert_logical", {
+  expect_silent(assert_logical(TRUE))
+  expect_error(assert_logical(1), "Expected '.+' to be logical")
+  expect_error(assert_logical("true"), "Expected '.+' to be logical")
+})
+
+
+test_that("assert_nonmissing", {
+  expect_silent(assert_nonmissing(1))
+  expect_error(assert_nonmissing(NA), "Expected '.+' to be non-NA")
+})

--- a/tests/testthat/test-util.R
+++ b/tests/testthat/test-util.R
@@ -4,3 +4,9 @@ test_that("null-or-value works", {
   expect_equal(NULL %||% NULL, NULL)
   expect_equal(NULL %||% 2, 2)
 })
+
+
+test_that("match_value", {
+  expect_error(match_value("foo", letters), "must be one of")
+  expect_silent(match_value("a", letters))
+})


### PR DESCRIPTION
This PR adds some basic helpers, with the logic ported from original odin.  The idea is that the user might (eventually) pass a couple of different things to `odin::odin()`:

* a language object representing the model, which we'd intercept before evaluation
* the model as a string
* the model as a string representing a file that contains the code

This PR contains the logic for detecting the version of this we've been given, including allowing the user to force a particular type, with errors thrown in the case where it's impossible, through to processing into a standard format for later.

Quite a few standard helpers/assertions included, and I've started on an `odin_parse` function which will start the integration of early features.

The next PR will contain basic parsing of individual statements