### PR TITLE
Generate simple ODE model

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,6 +14,7 @@ URL: https://mrc-ide.github.io/odin2, https://github.com/mrc-ide/odin2
 BugReports: https://github.com/mrc-ide/odin2/issues
 Imports:
     cli,
+    dust2,
     mcstate2,
     rlang
 Suggests:
@@ -24,6 +25,7 @@ Suggests:
     withr
 Config/testthat/edition: 3
 Remotes:
+    mrc-ide/dust2,
     mrc-ide/mcstate2
 VignetteBuilder: knitr
 Language: en-GB

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,6 +18,7 @@ Imports:
     mcstate2,
     rlang
 Suggests:
+    decor,
     knitr,
     rmarkdown,
     mockery,

--- a/R/generate_dust.R
+++ b/R/generate_dust.R
@@ -1,0 +1,281 @@
+generate_dust_system <- function(dat) {
+  dat$sexp_data <- generate_dust_dat(dat$storage$location)
+
+  body <- collector()
+  body$add("#include <dust2/common.hpp>")
+  body$add(generate_dust_system_core_attributes(dat))
+  body$add(sprintf("class %s {", dat$class))
+  body$add("public:")
+  body$add(sprintf("  %s() = delete;", dat$class))
+  body$add("  using real_type = double;")
+  body$add("  using rng_state_type = mcstate::random::generator<real_type>;")
+  body$add(sprintf("  %s", generate_dust_system_core_shared_state(dat)))
+  body$add(sprintf("  %s", generate_dust_system_core_internal_state(dat)))
+  body$add(sprintf("  %s", generate_dust_system_core_data_type(dat)))
+  body$add(sprintf("  %s", generate_dust_system_core_size_state(dat)))
+  body$add(sprintf("  %s", generate_dust_system_core_build_shared(dat)))
+  body$add(sprintf("  %s", generate_dust_system_core_build_internal(dat)))
+  body$add(sprintf("  %s", generate_dust_system_core_build_data(dat)))
+  body$add(sprintf("  %s", generate_dust_system_core_update_shared(dat)))
+  body$add(sprintf("  %s", generate_dust_system_core_update_internal(dat)))
+  body$add(sprintf("  %s", generate_dust_system_core_initial(dat)))
+  body$add(sprintf("  %s", generate_dust_system_core_update(dat)))
+  body$add(sprintf("  %s", generate_dust_system_core_rhs(dat)))
+  body$add(sprintf("  %s", generate_dust_system_core_zero_every(dat)))
+  body$add(sprintf("  %s", generate_dust_system_core_compare_data(dat)))
+  body$add("};")
+  body$get()
+}
+
+
+generate_dust_system_core_attributes <- function(dat) {
+  if (length(dat$phases$compare)) {
+    has_compare <- "// [[dust2::has_compare()]]"
+  } else {
+    has_compare <- NULL
+  }
+  c(sprintf("// [[dust2::class(%s)]]", dat$class),
+    sprintf("// [[dust2::time_type(%s)]]", dat$time),
+    has_compare)
+}
+
+
+generate_dust_system_core_shared_state <- function(dat) {
+  nms <- dat$storage$contents$shared
+  type <- dat$storage$type[nms]
+  c("struct shared_state {",
+    sprintf("  %s %s;", type, nms),
+    "};")
+}
+
+
+## This one is trivial until we pick up arrays
+generate_dust_system_core_internal_state <- function(dat) {
+  "struct internal_state {};"
+}
+
+
+generate_dust_system_core_data_type <- function(dat) {
+  data <- dat$storage$contents$data
+  if (nrow(data) == 0) {
+    "  using data_type = dust2::no_data;"
+  } else {
+    c("struct data_type {",
+      sprintf("  real_type %s;", data$name),
+      "};")
+  }
+}
+
+
+generate_dust_system_core_size_state <- function(dat) {
+  args <- c("const shared_state&" = "shared")
+  body <- sprintf("return %d;", length(dat$storage$contents$variables))
+  cpp_function("size_t", "size_state", args, body, static = TRUE)
+}
+
+
+generate_dust_system_core_build_shared <- function(dat) {
+  options <- list(shared_exists = FALSE)
+  eqs <- dat$phases$build_shared$equations
+  body <- collector()
+  for (eq in dat$equations[eqs]) {
+    lhs <- eq$lhs$name
+    if (eq$rhs$type == "parameter") {
+      rhs <- sprintf('dust2::r::read_real(parameters, "%s")', lhs)
+    } else {
+      rhs <- generate_dust_sexp(eq$rhs$expr, dat$sexp_data, options)
+    }
+    body$add(sprintf("const real_type %s = %s;", lhs, rhs))
+  }
+  body$add(sprintf("return shared_state{%s};", paste(eqs, collapse = ", ")))
+  args <- c("cpp11::list" = "parameters")
+  cpp_function("shared_state", "build_shared", args, body$get(), static = TRUE)
+}
+
+
+generate_dust_system_core_build_data <- function(dat) {
+  data <- dat$storage$contents$data
+  if (nrow(data) == 0) {
+    return(NULL)
+  }
+  ## This is very simple for now, but later we can allow data to have
+  ## types, lengths, etc.
+  eqs <- dat$phases$create_data$equations
+  body <- collector()
+  body$add("auto data = static_cast<cpp11::list>(r_data);")
+  body$add(sprintf('auto %s = dust2::r::read_real(data, "%s");',
+                   data$name, data$name))
+  body$add(sprintf("return data_type{%s};", paste(data, collapse = ", ")))
+  args <- c("cpp11::list" = "r_data")
+  cpp_function("data_type", "build_data", args, body$get(), static = TRUE)
+}
+
+
+generate_dust_system_core_build_internal <- function(dat) {
+  args <- c("const shared_state&" = "shared")
+  body <- "return internal_state{};"
+  cpp_function("internal_state", "build_internal", args, body, static = TRUE)
+}
+
+
+generate_dust_system_core_update_shared <- function(dat) {
+  eqs <- dat$phases$update_shared$equations
+  body <- collector()
+  for (eq in dat$equations[eqs]) {
+    name <- eq$lhs$name
+    lhs <- generate_dust_sexp(name, dat$sexp_data)
+    if (eq$rhs$type == "parameter") {
+      rhs <- sprintf('dust2::r::read_real(parameters, "%s", %s)', name, lhs)
+    } else {
+      rhs <- generate_dust_sexp(eq$rhs$expr, dat$sexp_data)
+    }
+    body$add(sprintf("%s = %s;", lhs, rhs))
+  }
+  args <- c("cpp11::list" = "parameters", "shared_state&" = "shared")
+  cpp_function("void", "update_shared", args, body$get(), static = TRUE)
+}
+
+
+generate_dust_system_core_update_internal <- function(dat) {
+  args <- c("const shared_state&" = "shared", "internal_state&" = "internal")
+  body <- character()
+  cpp_function("void", "update_internal", args, body, static = TRUE)
+}
+
+
+generate_dust_system_core_initial <- function(dat) {
+  if (dat$time == "continuous") {
+    args <- c("real_type" = "time",
+              "const shared_state&" = "shared",
+              "internal_state&" = "internal",
+              "rng_state_type&" = "rng_state",
+              "real_type*" = "state")
+  } else {
+    args <- c("real_type" = "time",
+              "real_type" = "dt",
+              "const shared_state&" = "shared",
+              "internal_state&" = "internal",
+              "rng_state_type&" = "rng_state",
+              "real_type*" = "state")
+  }
+  body <- collector()
+  eqs <- dat$phases$initial$equations
+  for (eq in c(dat$equations[eqs], dat$phases$initial$variables)) {
+    lhs <- generate_dust_lhs(eq$lhs$name, dat, "state")
+    rhs <- generate_dust_sexp(eq$rhs$expr, dat$sexp_data)
+    body$add(sprintf("%s = %s;", lhs, rhs))
+  }
+  cpp_function("void", "initial", args, body$get(), static = TRUE)
+}
+
+
+generate_dust_system_core_update <- function(dat) {
+  ## I think this is not quite the right condition, because we do want
+  ## this with a mixed model.
+  if (dat$time == "continuous") {
+    return(NULL)
+  }
+  args <- c("real_type" = "time",
+            "real_type" = "dt",
+            "const real_type*" = "state",
+            "const shared_state&" = "shared",
+            "internal_state&" = "internal",
+            "rng_state_type&" = "rng_state",
+            "real_type*" = "state_next")
+  body <- collector()
+  variables <- dat$storage$contents$variables
+  i <- variables %in% dat$phases$update$unpack
+  body$add(sprintf("const auto %s = state[%d];",
+                   variables[i],
+                   match(variables[i], dat$storage$packing$scalar) - 1))
+  eqs <- dat$phases$update$equations
+  for (eq in c(dat$equations[eqs], dat$phases$update$variables)) {
+    lhs <- generate_dust_lhs(eq$lhs$name, dat, "state_next")
+    rhs <- generate_dust_sexp(eq$rhs$expr, dat$sexp_data)
+    body$add(sprintf("%s = %s;", lhs, rhs))
+  }
+  cpp_function("void", "update", args, body$get(), static = TRUE)
+}
+
+
+generate_dust_system_core_rhs <- function(dat) {
+  if (dat$time == "discrete") {
+    return(NULL)
+  }
+  args <- c("real_type" = "time",
+            "const real_type*" = "state",
+            "const shared_state&" = "shared",
+            "internal_state&" = "internal",
+            "real_type*" = "state_deriv")
+  body <- collector()
+  variables <- dat$storage$contents$variables
+  i <- variables %in% dat$phases$deriv$unpack
+  body$add(sprintf("const auto %s = state[%d];",
+                   variables[i],
+                   match(variables[i], dat$storage$packing$scalar) - 1))
+  eqs <- dat$phases$deriv$equations
+  for (eq in c(dat$equations[eqs], dat$phases$deriv$variables)) {
+    lhs <- generate_dust_lhs(eq$lhs$name, dat, "state_deriv")
+    rhs <- generate_dust_sexp(eq$rhs$expr, dat$sexp_data)
+    body$add(sprintf("%s = %s;", lhs, rhs))
+  }
+  cpp_function("void", "rhs", args, body$get(), static = TRUE)
+}
+
+
+generate_dust_system_core_zero_every <- function(dat) {
+  args <- c("const shared_state&" = "shared")
+  body <- "return dust2::zero_every_type<real_type>();"
+  cpp_function("auto", "zero_every", args, body, static = TRUE)
+}
+
+
+generate_dust_system_core_compare_data <- function(dat) {
+  args <- c("real_type" = "time",
+            "real_type" = "dt",
+            "const real_type*" = "state",
+            "const data_type&" = "data",
+            "const shared_state&" = "shared",
+            "internal_state&" = "internal",
+            "rng_state_type&" = "rng_state")
+  body <- collector()
+  variables <- dat$storage$contents$variables
+  i <- variables %in% dat$phases$compare$unpack
+  body$add(sprintf("const auto %s = state[%d];",
+                   variables[i],
+                   match(variables[i], dat$storage$packing$scalar) - 1))
+  ## TODO collision here in names with 'll'; we might need to prefix
+  ## with compare_ perhaps?
+  body$add("real_type ll = 0;")
+
+  eqs <- dat$phases$compare$equations
+  for (eq in c(dat$equations[eqs])) {
+    lhs <- generate_dust_lhs(eq$lhs$name, dat, "state")
+    rhs <- generate_dust_sexp(eq$rhs$expr, dat$sexp_data)
+    body$add(sprintf("%s = %s;", lhs, rhs))
+  }
+
+  ## Then the actual comparison:
+  for (eq in dat$phases$compare$compare) {
+    body$add(sprintf("ll += %s;",
+                     generate_dust_sexp_compare(eq$rhs$expr, dat$sexp_data)))
+  }
+
+  body$add("return ll;")
+  cpp_function("real_type", "compare_data", args, body$get(), static = TRUE)
+}
+
+
+generate_dust_lhs <- function(name, dat, name_state) {
+  location <- dat$storage$location[[name]]
+  if (location == "stack") {
+    sprintf("const %s %s", dat$storage$type[[name]], name)
+  } else if (location == "state") {
+    ## TODO: this wil need to change, once we support arrays: at that
+    ## point we'll make this more efficient too by computing
+    ## expressions for access.
+    sprintf("%s[%s]", name_state, match(name, dat$storage$packing$scalar) - 1)
+  } else {
+    stop("Unsupported location")
+  }
+}

--- a/R/generate_dust.R
+++ b/R/generate_dust.R
@@ -63,11 +63,11 @@ generate_dust_system_internal_state <- function(dat) {
 
 generate_dust_system_data_type <- function(dat) {
   data <- dat$storage$contents$data
-  if (nrow(data) == 0) {
+  if (length(data) == 0) {
     "using data_type = dust2::no_data;"
   } else {
     c("struct data_type {",
-      sprintf("  real_type %s;", data$name),
+      sprintf("  real_type %s;", data),
       "};")
   }
 }
@@ -101,15 +101,14 @@ generate_dust_system_build_shared <- function(dat) {
 
 generate_dust_system_build_data <- function(dat) {
   data <- dat$storage$contents$data
-  if (nrow(data) == 0) {
+  if (length(data) == 0) {
     return(NULL)
   }
   ## This is very simple for now, but later we can allow data to have
   ## types, lengths, etc.
   eqs <- dat$phases$create_data$equations
   body <- collector()
-  body$add(sprintf('auto %s = dust2::r::read_real(data, "%s");',
-                   data$name, data$name))
+  body$add(sprintf('auto %s = dust2::r::read_real(data, "%s");', data, data))
   body$add(sprintf("return data_type{%s};", paste(data, collapse = ", ")))
   args <- c("cpp11::list" = "data")
   cpp_function("data_type", "build_data", args, body$get(), static = TRUE)
@@ -266,7 +265,7 @@ generate_dust_system_compare_data <- function(dat) {
   ## Then the actual comparison:
   for (eq in dat$phases$compare$compare) {
     eq_args <- vcapply(eq$rhs$args, generate_dust_sexp, dat$sexp_data)
-    body$add(sprintf("ll += mcstate::density::%s(rng, %s, true);",
+    body$add(sprintf("ll += mcstate::density::%s(%s, true);",
                      eq$rhs$distribution, paste(eq_args, collapse = ", ")))
   }
 

--- a/R/generate_dust.R
+++ b/R/generate_dust.R
@@ -3,26 +3,26 @@ generate_dust_system <- function(dat) {
 
   body <- collector()
   body$add("#include <dust2/common.hpp>")
-  body$add(generate_dust_system_core_attributes(dat))
+  body$add(generate_dust_system_attributes(dat))
   body$add(sprintf("class %s {", dat$class))
   body$add("public:")
   body$add(sprintf("  %s() = delete;", dat$class))
   body$add("  using real_type = double;")
   body$add("  using rng_state_type = mcstate::random::generator<real_type>;")
-  body$add(sprintf("  %s", generate_dust_system_core_shared_state(dat)))
-  body$add(sprintf("  %s", generate_dust_system_core_internal_state(dat)))
-  body$add(sprintf("  %s", generate_dust_system_core_data_type(dat)))
-  body$add(sprintf("  %s", generate_dust_system_core_size_state(dat)))
-  body$add(sprintf("  %s", generate_dust_system_core_build_shared(dat)))
-  body$add(sprintf("  %s", generate_dust_system_core_build_internal(dat)))
-  body$add(sprintf("  %s", generate_dust_system_core_build_data(dat)))
-  body$add(sprintf("  %s", generate_dust_system_core_update_shared(dat)))
-  body$add(sprintf("  %s", generate_dust_system_core_update_internal(dat)))
-  body$add(sprintf("  %s", generate_dust_system_core_initial(dat)))
-  body$add(sprintf("  %s", generate_dust_system_core_update(dat)))
-  body$add(sprintf("  %s", generate_dust_system_core_rhs(dat)))
-  body$add(sprintf("  %s", generate_dust_system_core_zero_every(dat)))
-  body$add(sprintf("  %s", generate_dust_system_core_compare_data(dat)))
+  body$add(sprintf("  %s", generate_dust_system_shared_state(dat)))
+  body$add(sprintf("  %s", generate_dust_system_internal_state(dat)))
+  body$add(sprintf("  %s", generate_dust_system_data_type(dat)))
+  body$add(sprintf("  %s", generate_dust_system_size_state(dat)))
+  body$add(sprintf("  %s", generate_dust_system_build_shared(dat)))
+  body$add(sprintf("  %s", generate_dust_system_build_internal(dat)))
+  body$add(sprintf("  %s", generate_dust_system_build_data(dat)))
+  body$add(sprintf("  %s", generate_dust_system_update_shared(dat)))
+  body$add(sprintf("  %s", generate_dust_system_update_internal(dat)))
+  body$add(sprintf("  %s", generate_dust_system_initial(dat)))
+  body$add(sprintf("  %s", generate_dust_system_update(dat)))
+  body$add(sprintf("  %s", generate_dust_system_rhs(dat)))
+  body$add(sprintf("  %s", generate_dust_system_zero_every(dat)))
+  body$add(sprintf("  %s", generate_dust_system_compare_data(dat)))
   body$add("};")
   body$get()
 }
@@ -34,7 +34,7 @@ generate_prepare <- function(dat) {
 }
 
 
-generate_dust_system_core_attributes <- function(dat) {
+generate_dust_system_attributes <- function(dat) {
   if (length(dat$phases$compare) > 0) {
     has_compare <- "// [[dust2::has_compare()]]"
   } else {
@@ -46,7 +46,7 @@ generate_dust_system_core_attributes <- function(dat) {
 }
 
 
-generate_dust_system_core_shared_state <- function(dat) {
+generate_dust_system_shared_state <- function(dat) {
   nms <- dat$storage$contents$shared
   type <- dat$storage$type[nms]
   c("struct shared_state {",
@@ -56,12 +56,12 @@ generate_dust_system_core_shared_state <- function(dat) {
 
 
 ## This one is trivial until we pick up arrays
-generate_dust_system_core_internal_state <- function(dat) {
+generate_dust_system_internal_state <- function(dat) {
   "struct internal_state {};"
 }
 
 
-generate_dust_system_core_data_type <- function(dat) {
+generate_dust_system_data_type <- function(dat) {
   data <- dat$storage$contents$data
   if (nrow(data) == 0) {
     "using data_type = dust2::no_data;"
@@ -73,14 +73,14 @@ generate_dust_system_core_data_type <- function(dat) {
 }
 
 
-generate_dust_system_core_size_state <- function(dat) {
+generate_dust_system_size_state <- function(dat) {
   args <- c("const shared_state&" = "shared")
   body <- sprintf("return %d;", length(dat$storage$contents$variables))
   cpp_function("size_t", "size_state", args, body, static = TRUE)
 }
 
 
-generate_dust_system_core_build_shared <- function(dat) {
+generate_dust_system_build_shared <- function(dat) {
   options <- list(shared_exists = FALSE)
   eqs <- dat$phases$build_shared$equations
   body <- collector()
@@ -99,7 +99,7 @@ generate_dust_system_core_build_shared <- function(dat) {
 }
 
 
-generate_dust_system_core_build_data <- function(dat) {
+generate_dust_system_build_data <- function(dat) {
   data <- dat$storage$contents$data
   if (nrow(data) == 0) {
     return(NULL)
@@ -116,14 +116,14 @@ generate_dust_system_core_build_data <- function(dat) {
 }
 
 
-generate_dust_system_core_build_internal <- function(dat) {
+generate_dust_system_build_internal <- function(dat) {
   args <- c("const shared_state&" = "shared")
   body <- "return internal_state{};"
   cpp_function("internal_state", "build_internal", args, body, static = TRUE)
 }
 
 
-generate_dust_system_core_update_shared <- function(dat) {
+generate_dust_system_update_shared <- function(dat) {
   eqs <- dat$phases$update_shared$equations
   body <- collector()
   for (eq in dat$equations[eqs]) {
@@ -141,14 +141,14 @@ generate_dust_system_core_update_shared <- function(dat) {
 }
 
 
-generate_dust_system_core_update_internal <- function(dat) {
+generate_dust_system_update_internal <- function(dat) {
   args <- c("const shared_state&" = "shared", "internal_state&" = "internal")
   body <- character()
   cpp_function("void", "update_internal", args, body, static = TRUE)
 }
 
 
-generate_dust_system_core_initial <- function(dat) {
+generate_dust_system_initial <- function(dat) {
   if (dat$time == "continuous") {
     args <- c("real_type" = "time",
               "const shared_state&" = "shared",
@@ -174,7 +174,7 @@ generate_dust_system_core_initial <- function(dat) {
 }
 
 
-generate_dust_system_core_update <- function(dat) {
+generate_dust_system_update <- function(dat) {
   ## I think this is not quite the right condition, because we do want
   ## this with a mixed model.
   if (dat$time == "continuous") {
@@ -203,7 +203,7 @@ generate_dust_system_core_update <- function(dat) {
 }
 
 
-generate_dust_system_core_rhs <- function(dat) {
+generate_dust_system_rhs <- function(dat) {
   if (dat$time == "discrete") {
     return(NULL)
   }
@@ -228,14 +228,14 @@ generate_dust_system_core_rhs <- function(dat) {
 }
 
 
-generate_dust_system_core_zero_every <- function(dat) {
+generate_dust_system_zero_every <- function(dat) {
   args <- c("const shared_state&" = "shared")
   body <- "return dust2::zero_every_type<real_type>();"
   cpp_function("auto", "zero_every", args, body, static = TRUE)
 }
 
 
-generate_dust_system_core_compare_data <- function(dat) {
+generate_dust_system_compare_data <- function(dat) {
   if (length(dat$phases$compare) == 0) {
     return(NULL)
   }

--- a/R/generate_dust.R
+++ b/R/generate_dust.R
@@ -266,7 +266,7 @@ generate_dust_system_compare_data <- function(dat) {
   ## Then the actual comparison:
   for (eq in dat$phases$compare$compare) {
     eq_args <- vcapply(eq$rhs$args, generate_dust_sexp, dat$sexp_data)
-    body$add(sprintf("ll += mcstate2::density::%s(rng, %s, true);",
+    body$add(sprintf("ll += mcstate::density::%s(rng, %s, true);",
                      eq$rhs$distribution, paste(eq_args, collapse = ", ")))
   }
 

--- a/R/generate_dust_sexp.R
+++ b/R/generate_dust_sexp.R
@@ -1,4 +1,4 @@
-generate_dust_sexp <- function(expr, dat, options) {
+generate_dust_sexp <- function(expr, dat, options = list()) {
   if (is.recursive(expr)) {
     fn <- as.character(expr[[1]])
     args <- vcapply(expr[-1], generate_dust_sexp, dat, options)

--- a/R/parse.R
+++ b/R/parse.R
@@ -4,9 +4,12 @@ odin_parse <- function(expr, input_type = NULL) {
   exprs <- lapply(dat$exprs, function(x) parse_expr(x$value, x, call = call))
 
   system <- parse_system_overall(exprs, call)
-  equations <- parse_system_depends(system$exprs$equations, system$variables,
-                                    call)
-  phases <- parse_system_phases(system$exprs, equations, system$variables, call)
+  equations <- parse_system_depends(
+    system$exprs$equations, system$variables, call)
+  phases <- parse_system_phases(
+    system$exprs, equations, system$variables, call)
+  storage <- parse_storage(
+    equations, phases, system$variables, system$data, call)
 
   ret <- list(time = system$time,
               class = "odin",
@@ -14,6 +17,7 @@ odin_parse <- function(expr, input_type = NULL) {
               parameters = system$parameters,
               equations = equations,
               phases = phases,
+              storage = storage,
               data = system$data)
 
   ret

--- a/R/parse.R
+++ b/R/parse.R
@@ -7,7 +7,7 @@ odin_parse <- function(expr, input_type = NULL) {
   equations <- parse_system_depends(
     system$exprs$equations, system$variables, call)
   phases <- parse_system_phases(
-    system$exprs, equations, system$variables, call)
+    system$exprs, equations, system$variables, system$data$name, call)
   storage <- parse_storage(
     equations, phases, system$variables, system$data, call)
 

--- a/R/parse_expr.R
+++ b/R/parse_expr.R
@@ -198,11 +198,8 @@ parse_expr_compare <- function(expr, src, call) {
   lhs <- parse_expr_compare_lhs(expr[[2]], src, call)
   rhs <- parse_expr_compare_rhs(expr[[3]], src, call)
 
-  ## Quickly rewrite the expression, at least for now:
-  rhs$expr <- as.call(c(list(rhs$expr[[1]], lhs),
-                        as.list(rhs$expr[-1])))
-  rhs$depends$variables <- union(rhs$depends$variables,
-                                 as.character(lhs))
+  rhs$args <- c(lhs, rhs$args)
+  rhs$depends$variables <- union(rhs$depends$variables, as.character(lhs))
   list(special = "compare",
        rhs = rhs,
        src = src)

--- a/R/parse_system.R
+++ b/R/parse_system.R
@@ -217,3 +217,37 @@ parse_system_phases <- function(exprs, equations, variables, call) {
 
   phases
 }
+
+
+parse_storage <- function(equations, phases, variables, data, call) {
+  ## This will need additional work once we support arrays as these
+  ## will be put into internal storage.
+  shared <- intersect(names(equations), phases$build_shared$equations)
+  stack <- setdiff(names(equations), shared)
+
+  contents <- list(
+    variables = variables,
+    shared = shared,
+    internal = character(),
+    data = data,
+    output = character(),
+    stack = stack)
+  location <- set_names(rep(names(contents), lengths(contents)),
+                        unlist(contents, FALSE, TRUE))
+  location[location == "variables"] <- "state"
+
+  ## We'll need integer variables soon, these are always weird.  We
+  ## could also use proper booleans too.
+  type <- set_names(rep("real_type", length(location)), names(location))
+
+  ## This will change soon, as we'll need more flexibility with
+  ## arrays, and output, and adjoints.  For now just record the
+  ## locations of variables and we'll work out what index these sit at
+  ## later.
+  packing <- list(scalar = variables)
+
+  list(contents = contents,
+       location = location,
+       type = type,
+       packing = packing)
+}

--- a/R/parse_system.R
+++ b/R/parse_system.R
@@ -7,7 +7,7 @@ parse_system_overall <- function(exprs, call) {
   is_compare <- special == "compare"
   is_data <- special == "data"
   is_parameter <- special == "parameter"
-  is_equation <- special %in% c("", "parameter", "data")
+  is_equation <- special %in% c("", "parameter")
 
   ## We take initial as the set of variables:
   variables <- vcapply(exprs[is_initial], function(x) x$lhs$name)
@@ -99,8 +99,10 @@ parse_system_overall <- function(exprs, call) {
 
 
 parse_system_depends <- function(equations, variables, call) {
-  implicit <- c(variables, "time", "dt")
+  automatic <- c("time", "dt")
+  implicit <- c(variables, automatic)
 
+  ## First, compute the topological order ignoring variables
   names(equations) <- vcapply(equations, function(eq) eq$lhs$name)
   deps <- lapply(equations, function(eq) {
     ## In an earlier proof-of-concept here we also removed eq$lhs$name
@@ -121,7 +123,11 @@ parse_system_depends <- function(equations, variables, call) {
       "E2005", src, call)
   }
 
-  deps <- deps[res$value]
+  ## Now, we need to get the variables a second time, and only exclude
+  ## automatic variables
+  deps <- lapply(equations[res$value], function(eq) {
+    setdiff(eq$rhs$depends$variables, automatic)
+  })
   deps_recursive <- list()
   for (nm in names(deps)) {
     vars <- deps[[nm]]
@@ -135,7 +141,7 @@ parse_system_depends <- function(equations, variables, call) {
 }
 
 
-parse_system_phases <- function(exprs, equations, variables, call) {
+parse_system_phases <- function(exprs, equations, variables, data, call) {
   ## First compute the 'stage' that things occur in; there are only
   ## three of these, but "time" covers a multitude of sins and
   ## includes things like the compare function as well as deriv/update
@@ -143,10 +149,12 @@ parse_system_phases <- function(exprs, equations, variables, call) {
   ## considered time).
   stages <- c(system_create = 1,
               parameter_update = 2,
-              time = 3)
+              time = 3,
+              data = 4)
   implicit <- c(variables, "time", "dt")
   stage <- c(
-    set_names(rep(stages[["time"]], length(implicit)), implicit))
+    set_names(rep(stages[["time"]], length(implicit)), implicit),
+    set_names(rep(stages[["data"]], length(data)), data))
   for (nm in names(equations)) {
     rhs <- equations[[nm]]$rhs
     if (identical(rhs$type, "parameter")) {
@@ -163,8 +171,6 @@ parse_system_phases <- function(exprs, equations, variables, call) {
   ## Now, we try and work out which parts of the graph are needed at
   ## different "phases".  These roughly correspond to dust functions.
 
-  used <- character()
-
   deps_recursive <- lapply(equations, function(x) {
     x$rhs$depends$variables_recursive
   })
@@ -172,10 +178,10 @@ parse_system_phases <- function(exprs, equations, variables, call) {
   used <- character()
   required <- character()
 
-  phases <- set_names(vector("list", 5),
-                      c("update", "deriv", "output", "initial", "compare"))
+  phase_names <- c("update", "deriv", "output", "initial", "compare")
+  phases <- set_names(vector("list", length(phase_names)), phase_names)
 
-  for (phase in names(phases)) {
+  for (phase in phase_names) {
     e <- exprs[[phase]]
     if (length(e) > 0) {
       deps <- unique(unlist(lapply(e, function(x) x$rhs$depends$variables),
@@ -184,9 +190,11 @@ parse_system_phases <- function(exprs, equations, variables, call) {
       eqs <- union(eqs, unlist(deps_recursive[eqs], FALSE, FALSE))
       used <- union(used, eqs)
 
-      eqs_time <- intersect(names(equations), eqs[stage[eqs] == "time"])
-      unpack <- intersect(deps, variables)
-      required <- union(required, eqs[stage[eqs] != "time"])
+      is_time <- stage[eqs] == "time"
+      is_data <- stage[eqs] == "data"
+      eqs_time <- intersect(names(equations), eqs[is_time])
+      unpack <- intersect(variables, c(eqs, deps))
+      required <- union(required, eqs[!(is_time | is_data)])
 
       if (phase %in% c("update", "deriv", "output")) {
         phases[[phase]] <- list(unpack = unpack,
@@ -203,7 +211,8 @@ parse_system_phases <- function(exprs, equations, variables, call) {
         phases[[phase]] <- list(equations = eqs_time,
                                 variables = e)
       } else if (phase == "compare") {
-        phases[[phase]] <- list(equations = eqs_time,
+        eqs_data <- intersect(names(equations), eqs[is_time | is_data])
+        phases[[phase]] <- list(equations = eqs_data,
                                 unpack = unpack,
                                 compare = e)
       }
@@ -229,7 +238,7 @@ parse_storage <- function(equations, phases, variables, data, call) {
     variables = variables,
     shared = shared,
     internal = character(),
-    data = data,
+    data = data$name,
     output = character(),
     stack = stack)
   location <- set_names(rep(names(contents), lengths(contents)),

--- a/R/util_cpp.R
+++ b/R/util_cpp.R
@@ -1,0 +1,14 @@
+cpp_function <- function(return_type, name, args, body, static = FALSE) {
+  c(cpp_args(return_type, name, args, static = static),
+    sprintf("  %s", body),
+    "}")
+}
+
+
+cpp_args <- function(return_type, name, args, static = FALSE) {
+  static_str <- if (static) "static " else ""
+  args_str <- paste(sprintf("%s %s", names(args), unname(args)),
+                    collapse = ", ")
+  sprintf("%s%s %s(%s) {",
+          static_str, return_type, name, args_str)
+}

--- a/tests/testthat/helper-odin2.R
+++ b/tests/testthat/helper-odin2.R
@@ -1,0 +1,14 @@
+# nolint start
+method_args <- list(
+  size_state = "static size_t size_state(const shared_state& shared) {",
+  build_shared = "static shared_state build_shared(cpp11::list parameters) {",
+  build_data = "static data_type build_data(cpp11::list data) {",
+  initial_discrete = "static void initial(real_type time, real_type dt, const shared_state& shared, internal_state& internal, rng_state_type& rng_state, real_type* state) {",
+  initial_continuous = "static void initial(real_type time, const shared_state& shared, internal_state& internal, rng_state_type& rng_state, real_type* state) {",
+  update_shared = "static void update_shared(cpp11::list parameters, shared_state& shared) {",
+  build_internal = "static internal_state build_internal(const shared_state& shared) {",
+  update_internal = "static void update_internal(const shared_state& shared, internal_state& internal) {",
+  update = "static void update(real_type time, real_type dt, const real_type* state, const shared_state& shared, internal_state& internal, rng_state_type& rng_state, real_type* state_next) {",
+  rhs = "static void rhs(real_type time, const real_type* state, const shared_state& shared, internal_state& internal, real_type* state_deriv) {",
+  compare_data = "static real_type compare_data(real_type time, real_type dt, const real_type* state, const data_type& data, const shared_state& shared, internal_state& internal, rng_state_type& rng_state) {")
+# nolint end

--- a/tests/testthat/test-generate.R
+++ b/tests/testthat/test-generate.R
@@ -295,7 +295,7 @@ test_that("can build simple compare function", {
     c(method_args$compare_data,
       "  const auto x = state[0];",
       "  real_type ll = 0;",
-      "  ll += mcstate2::density::normal(rng, shared.d, x, 1, true);",
+      "  ll += mcstate::density::normal(rng, shared.d, x, 1, true);",
       "  return ll;",
       "}"))
 })
@@ -316,7 +316,7 @@ test_that("can build more complex compare function", {
       "  const auto x = state[0];",
       "  real_type ll = 0;",
       "  const real_type a = x / shared.d;",
-      "  ll += mcstate2::density::normal(rng, shared.d, x, a, true);",
+      "  ll += mcstate::density::normal(rng, shared.d, x, a, true);",
       "  return ll;",
       "}"))
 })

--- a/tests/testthat/test-generate.R
+++ b/tests/testthat/test-generate.R
@@ -1,0 +1,282 @@
+test_that("generate basic attributes for trivial system", {
+  dat <- odin_parse({
+    update(x) <- 1
+    initial(x) <- 1
+  })
+  dat <- generate_prepare(dat)
+  expect_equal(
+    generate_dust_system_core_attributes(dat),
+    c("// [[dust2::class(odin)]]",
+      "// [[dust2::time_type(discrete)]]"))
+})
+
+
+test_that("generate trivial types for trivial system", {
+  dat <- odin_parse({
+    update(x) <- 1
+    initial(x) <- 1
+  })
+  dat <- generate_prepare(dat)
+  expect_equal(
+    generate_dust_system_core_shared_state(dat),
+    c("struct shared_state {", "};"))
+  expect_equal(
+    generate_dust_system_core_internal_state(dat),
+    "struct internal_state {};")
+  expect_equal(
+    generate_dust_system_core_data_type(dat),
+    "using data_type = dust2::no_data;")
+})
+
+
+test_that("don't generate compare functions for systems without them", {
+  dat <- odin_parse({
+    update(x) <- 1
+    initial(x) <- 1
+  })
+  dat <- generate_prepare(dat)
+  expect_null(generate_dust_system_core_compare_data(dat))
+})
+
+
+test_that("generate basic attributes for system with compare", {
+  dat <- odin_parse({
+    update(x) <- 1
+    initial(x) <- 1
+    d <- data()
+    compare(d) ~ Normal(x, 1)
+  })
+  dat <- generate_prepare(dat)
+  expect_equal(
+    generate_dust_system_core_attributes(dat),
+    c("// [[dust2::class(odin)]]",
+      "// [[dust2::time_type(discrete)]]",
+      "// [[dust2::has_compare()]]"))
+})
+
+
+test_that("generate data type where used", {
+  dat <- odin_parse({
+    update(x) <- 1
+    initial(x) <- 1
+    d1 <- data()
+    d2 <- data()
+  })
+  dat <- generate_prepare(dat)
+  expect_equal(
+    generate_dust_system_core_data_type(dat),
+    c("struct data_type {",
+      "  real_type d1;",
+      "  real_type d2;",
+      "};"))
+})
+
+
+test_that("generate shared storage where used", {
+  dat <- odin_parse({
+    a <- 1
+    b <- parameter()
+    c <- a + b
+    initial(x) <- 1
+    update(x) <- x + c
+  })
+  dat <- generate_prepare(dat)
+  expect_equal(
+    generate_dust_system_core_shared_state(dat),
+    c("struct shared_state {",
+      "  real_type a;",
+      "  real_type b;",
+      "  real_type c;",
+      "};"))
+})
+
+
+test_that("can generate size_state function for system of all scalars", {
+  dat <- odin_parse({
+    initial(x) <- 1
+    update(x) <- 1
+    initial(y) <- 1
+    update(y) <- 1
+  })
+  dat <- generate_prepare(dat)
+  expect_equal(
+    generate_dust_system_core_size_state(dat),
+    c(method_args$size_state,
+      "  return 2;",
+      "}"))
+})
+
+
+test_that("can generate build shared for trivial system", {
+  dat <- odin_parse({
+    initial(x) <- 1
+    update(x) <- 1
+  })
+  dat <- generate_prepare(dat)
+  expect_equal(
+    generate_dust_system_core_build_shared(dat),
+    c(method_args$build_shared,
+      "  return shared_state{};",
+      "}"))
+})
+
+
+test_that("can generate build shared with calculations", {
+  dat <- odin_parse({
+    initial(x) <- 1
+    update(x) <- b
+    a <- parameter()
+    b <- a * 2
+  })
+  dat <- generate_prepare(dat)
+  expect_equal(
+    generate_dust_system_core_build_shared(dat),
+    c(method_args$build_shared,
+      '  const real_type a = dust2::r::read_real(parameters, "a");',
+      "  const real_type b = a * 2;",
+      "  return shared_state{a, b};",
+      "}"))
+})
+
+
+test_that("don't create build data method for system that lacks data", {
+  dat <- odin_parse({
+    initial(x) <- 1
+    update(x) <- 1
+  })
+  dat <- generate_prepare(dat)
+  expect_null(generate_dust_system_core_build_data(dat))
+})
+
+
+test_that("create simple build data function", {
+  dat <- odin_parse({
+    initial(x) <- 1
+    update(x) <- 1
+    d <- data()
+  })
+  dat <- generate_prepare(dat)
+  expect_equal(
+    generate_dust_system_core_build_data(dat),
+    c(method_args$build_data,
+      "  auto d = dust2::r::read_real(data, \"d\");",
+      "  return data_type{d};",
+      "}"))
+})
+
+
+test_that("generate trivial update_shared if all parameters constant", {
+  dat <- odin_parse({
+    initial(x) <- 1
+    update(x) <- 1 + p
+    p <- parameter(constant = TRUE)
+  })
+  dat <- generate_prepare(dat)
+  expect_equal(
+    generate_dust_system_core_update_shared(dat),
+    c(method_args$update_shared,
+      "}"))
+})
+
+
+test_that("generate nontrivial update_shared if some parameters non-constant", {
+  dat <- odin_parse({
+    initial(x) <- 1
+    update(x) <- 1 + p / q + q2
+    p <- parameter(constant = TRUE)
+    q <- parameter()
+    q2 <- q * q
+  })
+  dat <- generate_prepare(dat)
+  expect_equal(
+    generate_dust_system_core_update_shared(dat),
+    c(method_args$update_shared,
+      "  shared.q = dust2::r::read_real(parameters, \"q\", shared.q);",
+      "  shared.q2 = shared.q * shared.q;",
+      "}"))
+})
+
+
+test_that("simple systems generate trivial build_internal function", {
+  dat <- odin_parse({
+    initial(x) <- 1
+    update(x) <- 1
+  })
+  dat <- generate_prepare(dat)
+  expect_equal(
+    generate_dust_system_core_build_internal(dat),
+    c(method_args$build_internal,
+      "  return internal_state{};",
+      "}"))
+})
+
+
+test_that("simple systems generate trivial update_internal function", {
+  dat <- odin_parse({
+    initial(x) <- 1
+    update(x) <- 1
+  })
+  dat <- generate_prepare(dat)
+  expect_equal(
+    generate_dust_system_core_update_internal(dat),
+    c(method_args$update_internal,
+      "}"))
+})
+
+
+test_that("generate trivial discrete time initial conditions", {
+  dat <- odin_parse({
+    initial(x) <- 1
+    update(x) <- 1
+  })
+  dat <- generate_prepare(dat)
+  expect_equal(
+    generate_dust_system_core_initial(dat),
+    c(method_args$initial_discrete,
+      "  state[0] = 1;",
+      "}"))
+})
+
+
+test_that("generate trivial continuous time initial conditions", {
+  dat <- odin_parse({
+    initial(x) <- 1
+    deriv(x) <- 1
+  })
+  dat <- generate_prepare(dat)
+  expect_equal(
+    generate_dust_system_core_initial(dat),
+    c(method_args$initial_continuous,
+      "  state[0] = 1;",
+      "}"))
+})
+
+
+test_that("can generate simple update method", {
+  dat <- odin_parse({
+    initial(x) <- 1
+    update(x) <- 1
+  })
+  dat <- generate_prepare(dat)
+  expect_equal(
+    generate_dust_system_core_update(dat),
+    c(method_args$update,
+      "  state_next[0] = 1;",
+      "}"))
+  expect_null(generate_dust_system_core_deriv(dat))
+})
+
+
+test_that("can generate simple deriv method", {
+  dat <- odin_parse({
+    initial(x) <- 1
+    deriv(x) <- 1
+  })
+  dat <- generate_prepare(dat)
+  expect_equal(
+    generate_dust_system_core_rhs(dat),
+    c(method_args$rhs,
+      "  state_deriv[0] = 1;",
+      "}"))
+  expect_null(generate_dust_system_core_update(dat))
+})

--- a/tests/testthat/test-generate.R
+++ b/tests/testthat/test-generate.R
@@ -5,7 +5,7 @@ test_that("generate basic attributes for trivial system", {
   })
   dat <- generate_prepare(dat)
   expect_equal(
-    generate_dust_system_core_attributes(dat),
+    generate_dust_system_attributes(dat),
     c("// [[dust2::class(odin)]]",
       "// [[dust2::time_type(discrete)]]"))
 })
@@ -18,13 +18,13 @@ test_that("generate trivial types for trivial system", {
   })
   dat <- generate_prepare(dat)
   expect_equal(
-    generate_dust_system_core_shared_state(dat),
+    generate_dust_system_shared_state(dat),
     c("struct shared_state {", "};"))
   expect_equal(
-    generate_dust_system_core_internal_state(dat),
+    generate_dust_system_internal_state(dat),
     "struct internal_state {};")
   expect_equal(
-    generate_dust_system_core_data_type(dat),
+    generate_dust_system_data_type(dat),
     "using data_type = dust2::no_data;")
 })
 
@@ -35,7 +35,7 @@ test_that("don't generate compare functions for systems without them", {
     initial(x) <- 1
   })
   dat <- generate_prepare(dat)
-  expect_null(generate_dust_system_core_compare_data(dat))
+  expect_null(generate_dust_system_compare_data(dat))
 })
 
 
@@ -48,7 +48,7 @@ test_that("generate basic attributes for system with compare", {
   })
   dat <- generate_prepare(dat)
   expect_equal(
-    generate_dust_system_core_attributes(dat),
+    generate_dust_system_attributes(dat),
     c("// [[dust2::class(odin)]]",
       "// [[dust2::time_type(discrete)]]",
       "// [[dust2::has_compare()]]"))
@@ -64,7 +64,7 @@ test_that("generate data type where used", {
   })
   dat <- generate_prepare(dat)
   expect_equal(
-    generate_dust_system_core_data_type(dat),
+    generate_dust_system_data_type(dat),
     c("struct data_type {",
       "  real_type d1;",
       "  real_type d2;",
@@ -82,7 +82,7 @@ test_that("generate shared storage where used", {
   })
   dat <- generate_prepare(dat)
   expect_equal(
-    generate_dust_system_core_shared_state(dat),
+    generate_dust_system_shared_state(dat),
     c("struct shared_state {",
       "  real_type a;",
       "  real_type b;",
@@ -100,7 +100,7 @@ test_that("can generate size_state function for system of all scalars", {
   })
   dat <- generate_prepare(dat)
   expect_equal(
-    generate_dust_system_core_size_state(dat),
+    generate_dust_system_size_state(dat),
     c(method_args$size_state,
       "  return 2;",
       "}"))
@@ -114,7 +114,7 @@ test_that("can generate build shared for trivial system", {
   })
   dat <- generate_prepare(dat)
   expect_equal(
-    generate_dust_system_core_build_shared(dat),
+    generate_dust_system_build_shared(dat),
     c(method_args$build_shared,
       "  return shared_state{};",
       "}"))
@@ -130,7 +130,7 @@ test_that("can generate build shared with calculations", {
   })
   dat <- generate_prepare(dat)
   expect_equal(
-    generate_dust_system_core_build_shared(dat),
+    generate_dust_system_build_shared(dat),
     c(method_args$build_shared,
       '  const real_type a = dust2::r::read_real(parameters, "a");',
       "  const real_type b = a * 2;",
@@ -145,7 +145,7 @@ test_that("don't create build data method for system that lacks data", {
     update(x) <- 1
   })
   dat <- generate_prepare(dat)
-  expect_null(generate_dust_system_core_build_data(dat))
+  expect_null(generate_dust_system_build_data(dat))
 })
 
 
@@ -157,7 +157,7 @@ test_that("create simple build data function", {
   })
   dat <- generate_prepare(dat)
   expect_equal(
-    generate_dust_system_core_build_data(dat),
+    generate_dust_system_build_data(dat),
     c(method_args$build_data,
       "  auto d = dust2::r::read_real(data, \"d\");",
       "  return data_type{d};",
@@ -173,7 +173,7 @@ test_that("generate trivial update_shared if all parameters constant", {
   })
   dat <- generate_prepare(dat)
   expect_equal(
-    generate_dust_system_core_update_shared(dat),
+    generate_dust_system_update_shared(dat),
     c(method_args$update_shared,
       "}"))
 })
@@ -189,7 +189,7 @@ test_that("generate nontrivial update_shared if some parameters non-constant", {
   })
   dat <- generate_prepare(dat)
   expect_equal(
-    generate_dust_system_core_update_shared(dat),
+    generate_dust_system_update_shared(dat),
     c(method_args$update_shared,
       "  shared.q = dust2::r::read_real(parameters, \"q\", shared.q);",
       "  shared.q2 = shared.q * shared.q;",
@@ -204,7 +204,7 @@ test_that("simple systems generate trivial build_internal function", {
   })
   dat <- generate_prepare(dat)
   expect_equal(
-    generate_dust_system_core_build_internal(dat),
+    generate_dust_system_build_internal(dat),
     c(method_args$build_internal,
       "  return internal_state{};",
       "}"))
@@ -218,7 +218,7 @@ test_that("simple systems generate trivial update_internal function", {
   })
   dat <- generate_prepare(dat)
   expect_equal(
-    generate_dust_system_core_update_internal(dat),
+    generate_dust_system_update_internal(dat),
     c(method_args$update_internal,
       "}"))
 })
@@ -231,7 +231,7 @@ test_that("generate trivial discrete time initial conditions", {
   })
   dat <- generate_prepare(dat)
   expect_equal(
-    generate_dust_system_core_initial(dat),
+    generate_dust_system_initial(dat),
     c(method_args$initial_discrete,
       "  state[0] = 1;",
       "}"))
@@ -245,7 +245,7 @@ test_that("generate trivial continuous time initial conditions", {
   })
   dat <- generate_prepare(dat)
   expect_equal(
-    generate_dust_system_core_initial(dat),
+    generate_dust_system_initial(dat),
     c(method_args$initial_continuous,
       "  state[0] = 1;",
       "}"))
@@ -259,11 +259,11 @@ test_that("can generate simple update method", {
   })
   dat <- generate_prepare(dat)
   expect_equal(
-    generate_dust_system_core_update(dat),
+    generate_dust_system_update(dat),
     c(method_args$update,
       "  state_next[0] = 1;",
       "}"))
-  expect_null(generate_dust_system_core_rhs(dat))
+  expect_null(generate_dust_system_rhs(dat))
 })
 
 
@@ -274,11 +274,11 @@ test_that("can generate simple deriv method", {
   })
   dat <- generate_prepare(dat)
   expect_equal(
-    generate_dust_system_core_rhs(dat),
+    generate_dust_system_rhs(dat),
     c(method_args$rhs,
       "  state_deriv[0] = 1;",
       "}"))
-  expect_null(generate_dust_system_core_update(dat))
+  expect_null(generate_dust_system_update(dat))
 })
 
 
@@ -291,7 +291,7 @@ test_that("can build simple compare function", {
   })
   dat <- generate_prepare(dat)
   expect_equal(
-    generate_dust_system_core_compare_data(dat),
+    generate_dust_system_compare_data(dat),
     c(method_args$compare_data,
       "  const auto x = state[0];",
       "  real_type ll = 0;",
@@ -311,7 +311,7 @@ test_that("can build more complex compare function", {
   })
   dat <- generate_prepare(dat)
   expect_equal(
-    generate_dust_system_core_compare_data(dat),
+    generate_dust_system_compare_data(dat),
     c(method_args$compare_data,
       "  const auto x = state[0];",
       "  real_type ll = 0;",
@@ -330,7 +330,7 @@ test_that("generate stack equations during update", {
   })
   dat <- generate_prepare(dat)
   expect_equal(
-    generate_dust_system_core_update(dat),
+    generate_dust_system_update(dat),
     c(method_args$update,
       "  const auto x = state[0];",
       "  const real_type a = 1 / x;",

--- a/tests/testthat/test-parse-expr-compare.R
+++ b/tests/testthat/test-parse-expr-compare.R
@@ -3,7 +3,7 @@ test_that("Can parse compare expression", {
   expect_equal(res$special, "compare")
   expect_equal(res$rhs$type, "compare")
   expect_equal(res$rhs$distribution, "normal")
-  expect_equal(res$rhs$args, list(0, 1))
+  expect_equal(res$rhs$args, list(quote(x), 0, 1))
   expect_equal(res$rhs$depends,
                list(functions = "Normal", variables = "x"))
 })

--- a/tests/testthat/test-parse-system.R
+++ b/tests/testthat/test-parse-system.R
@@ -159,3 +159,27 @@ test_that("prevent dependencies among variables in initial conditions", {
     }),
     "Dependencies within initial conditions not yet supported")
 })
+
+
+test_that("unpack indirect variables in compare", {
+  dat <- odin_parse({
+    update(x) <- 1
+    initial(x) <- 1
+    p <- exp(x)
+    d <- data()
+    compare(d) ~ Poisson(p)
+  })
+
+  expect_equal(dat$phases$compare$unpack, "x")
+  expect_equal(dat$phases$compare$equations, "p")
+  expect_length(dat$phases$compare$compare, 1)
+})
+
+
+test_that("unpack self-referential variables", {
+  dat <- odin_parse({
+    update(a) <- a + 1
+    initial(a) <- 1
+  })
+  expect_equal(dat$phases$update$unpack, "a")
+})

--- a/tests/testthat/test-util-cpp.R
+++ b/tests/testthat/test-util-cpp.R
@@ -1,0 +1,16 @@
+test_that("can create simple C++ functions", {
+  expect_equal(
+    cpp_function("a", "b", list("int" = "x"), "return x;"),
+    c("a b(int x) {",
+      "  return x;",
+      "}"))
+  expect_equal(
+    cpp_function("a", "b", list("int" = "x"), "return x;", static = TRUE),
+    c("static a b(int x) {",
+      "  return x;",
+      "}"))
+  expect_equal(
+    cpp_function("a", "b", list("int" = "x"), character()),
+    c("a b(int x) {",
+      "}"))
+})

--- a/tests/testthat/test-zzz-integration.R
+++ b/tests/testthat/test-zzz-integration.R
@@ -1,0 +1,42 @@
+test_that("can compile a simple ode model", {
+  dat <- odin_parse({
+    deriv(S) <- -beta * S * I / N
+    deriv(I) <- beta * S * I / N - gamma * I
+    deriv(R) <- gamma * I
+    N <- parameter(1000, constant = TRUE)
+    initial(S) <- N - I0
+    initial(I) <- I0
+    initial(R) <- 0
+    beta <- parameter(0.2)
+    gamma <- parameter(0.1)
+    I0 <- parameter(10)
+  })
+
+  code <- generate_dust_system(dat)
+  path <- "dust.cpp"
+  unlink(path)
+  writeLines(code, path)
+  res <- dust2::dust_compile(path, debug = TRUE, quiet = TRUE)
+  expect_s3_class(res(), "dust_system_generator")
+  expect_mapequal(res()$properties,
+                  list(time_type = "continuous",
+                       has_compare = FALSE))
+
+  pars <- list(N = 100, beta = 0.2, gamma = 0.1, I0 = 1)
+  sys <- dust2::dust_system_create(res(), pars, 1)
+  expect_s3_class(sys, "dust_system")
+  dust2::dust_system_set_state_initial(sys)
+  expect_equal(dust2::dust_system_state(sys), cbind(c(99, 1, 0)))
+
+  dust2::dust_system_run_to_time(sys, 10)
+  s <- dust2::dust_system_state(sys)
+
+  cmp <- local({
+    sys <- dust2::dust_system_create(dust2:::sirode(), pars, 1)
+    dust2::dust_system_set_state_initial(sys)
+    dust2::dust_system_run_to_time(sys, 10)
+    dust2::dust_system_state(sys)
+  })
+
+  expect_equal(s, cmp[1:3, , drop = FALSE])
+})

--- a/tests/testthat/test-zzz-integration.R
+++ b/tests/testthat/test-zzz-integration.R
@@ -40,3 +40,79 @@ test_that("can compile a simple ode model", {
 
   expect_equal(s, cmp[1:3, , drop = FALSE])
 })
+
+
+test_that("can compile a discrete-time model that compares to data", {
+  dat <- odin_parse({
+    ## Core equations for transitions between compartments:
+    update(S) <- S - n_SI
+    update(I) <- I + n_SI - n_IR
+    update(R) <- R + n_IR
+    update(cases_cumul) <- cases_cumul + n_SI
+    update(cases_inc) <- n_SI # for now, needs the resetting implemented!
+
+    ## Individual probabilities of transition:
+    p_SI <- 1 - exp(-beta * I / N * dt) # S to I
+    p_IR <- 1 - exp(-gamma * dt) # I to R
+
+    ## Draws from binomial distributions for numbers changing between
+    ## compartments:
+    n_SI <- S * p_SI # rbinom(S, p_SI)
+    n_IR <- I * p_IR # rbinom(I, p_IR)
+
+    ## Initial states:
+    initial(S) <- N - I0
+    initial(I) <- I0
+    initial(R) <- 0
+    initial(cases_cumul) <- 0
+    initial(cases_inc) <- 0
+
+    ## User defined parameters - default in parentheses:
+    N <- parameter(1000)
+    I0 <- parameter(10)
+    beta <- parameter(0.2)
+    gamma <- parameter(0.1)
+    exp_noise <- parameter(1e6)
+
+    ## Data and comparison
+    noise <- 1 / exp_noise # Exponential(rate = exp_noise)
+    incidence <- data()
+    lambda <- cases_inc + noise
+    compare(incidence) ~ Poisson(lambda)
+  })
+
+  code <- generate_dust_system(dat)
+  path <- "dust.cpp"
+  unlink(path)
+  writeLines(code, path)
+  res <- dust2::dust_compile(path, debug = TRUE, quiet = TRUE)
+  expect_s3_class(res(), "dust_system_generator")
+  expect_mapequal(res()$properties,
+                  list(time_type = "discrete",
+                       has_compare = TRUE))
+
+  pars <- list(N = 1000, beta = 0.2, gamma = 0.1, I0 = 10,
+               exp_noise = 1e6)
+  d <- list(incidence = 5)
+
+  sys <- dust2::dust_system_create(res(), pars, 1, deterministic = TRUE)
+  expect_s3_class(sys, "dust_system")
+  dust2::dust_system_set_state_initial(sys)
+  expect_equal(dust2::dust_system_state(sys), cbind(c(990, 10, 0, 0, 0)))
+
+  dust2::dust_system_run_to_time(sys, 10)
+  state <- dust2::dust_system_state(sys)
+  density <- dust2::dust_system_compare_data(sys, d)
+
+  cmp <- local({
+    sys <- dust2::dust_system_create(dust2:::sir(), pars, 1,
+                                     deterministic = TRUE)
+    dust2::dust_system_set_state_initial(sys)
+    dust2::dust_system_run_to_time(sys, 10)
+    list(state = dust2::dust_system_state(sys),
+         density = dust2::dust_system_compare_data(sys, d))
+  })
+
+  expect_equal(state, cmp$state)
+  expect_equal(density, cmp$density)
+})


### PR DESCRIPTION
Generate enough to generate, compile, and run some simple models.

We can generate both the ode and discrete time versions of the sir model in the dust package, and these are used in the tests.  There are only two actual model compilations here, which is probably not enough, but these are quite slow compared with the original odin.  Instead there are more tests that check the generated code for a single method - this is actually quite nice I think