### PR TITLE
Create differentiable models from stochastic ones

### DIFF
--- a/R/generate_dust_sexp.R
+++ b/R/generate_dust_sexp.R
@@ -33,7 +33,7 @@ generate_dust_sexp <- function(expr, dat, options = list()) {
       ## parens for now.
       ret <- sprintf("(%s ? %s : %s)", args[[1L]], args[[2L]], args[[3L]])
     } else if (is_stochastic_call) {
-      ret <- sprintf("mcstate::random::%s(rng, %s)",
+      ret <- sprintf("mcstate::random::%s(rng_state, %s)",
                      fn, paste(args, collapse = ", "))
     } else {
       ## TODO: we should catch this during parse; erroring here is a

--- a/R/parse_adjoint.R
+++ b/R/parse_adjoint.R
@@ -135,8 +135,13 @@ adjoint_equation <- function(nm, equations, intermediate, accumulate) {
     if (identical(eq$special, "compare")) {
       differentiate(eq$rhs$density$expr, nm)
     } else {
+      if (isTRUE(eq$rhs$is_stochastic)) {
+        expr <- rewrite_stochastic_to_expectation(eq$rhs$expr)
+      } else {
+        expr <- eq$rhs$expr
+      }
       maths$times(as.name(paste0(prefix, eq$lhs$name)),
-                  differentiate(eq$rhs$expr, nm))
+                  differentiate(expr, nm))
     }
   }
 

--- a/tests/testthat/test-generate.R
+++ b/tests/testthat/test-generate.R
@@ -485,6 +485,6 @@ test_that("can generate simple stochastic system", {
     generate_dust_system_update(dat),
     c(method_args$update,
       "  const auto x = state[0];",
-      "  state_next[0] = mcstate::random::normal(rng, x, 1);",
+      "  state_next[0] = mcstate::random::normal(rng_state, x, 1);",
       "}"))
 })

--- a/tests/testthat/test-parse-adjoint.R
+++ b/tests/testthat/test-parse-adjoint.R
@@ -7,8 +7,8 @@ test_that("can parse nontrivial system with adjoint", {
     N <- S + I + R
     p_inf <- beta * I / N * dt
     p_SI <- 1 - exp(-p_inf)
-    n_SI <- S * p_SI # Binomial(S, p_SI)
-    n_IR <- I * p_IR # Binomial(I, p_IR)
+    n_SI <- Binomial(S, p_SI)
+    n_IR <- Binomial(I, p_IR)
     update(S) <- S - n_SI
     update(I) <- I + n_SI - n_IR
     update(R) <- R + n_IR

--- a/tests/testthat/test-parse-expr.R
+++ b/tests/testthat/test-parse-expr.R
@@ -217,6 +217,40 @@ test_that("can parse expressions that involve stochastics", {
 })
 
 
+test_that("can parse compound expressions that involve stochastics", {
+  res <- parse_expr(quote(a <- Normal(0, 1) + Binomial(n, p)), NULL, NULL)
+
+  expect_identical(
+    res$rhs$expr[[2]],
+    quote(OdinStochasticCall(sample = "normal",
+                             density = "normal",
+                             mean = 0)(0, 1)))
+  expect_identical(
+    res$rhs$expr[[3]],
+    quote(OdinStochasticCall(sample = "binomial",
+                             density = NULL,
+                             mean = n * p)(n, p)))
+  expect_equal(res$rhs$depends,
+               list(functions = c("Normal", "Binomial"),
+                    variables = character("n", "p")))
+  expect_true(res$rhs$is_stochastic)
+
+  expect_identical(rewrite_stochastic_to_expectation(res$rhs$expr),
+                   quote(0 + n * p))
+})
+
+
+test_that("can parse recursive expressions that involve stochastics", {
+  res <- parse_expr(quote(a <- Normal(Poisson(p), Exponential(r))),
+                    NULL, NULL)
+  expect_equal(res$rhs$expr[[1]]$mean, quote(p))
+
+  res <- parse_expr(quote(a <- Normal(Poisson(Exponential(r)), 1)),
+                    NULL, NULL)
+  expect_equal(res$rhs$expr[[1]]$mean, quote(1 / r))
+})
+
+
 test_that("throw sensible error if stochastic parse fails", {
   expect_error(
     parse_expr(quote(a <- Normal(mu = 0, sigma = 1)), NULL, NULL),

--- a/tests/testthat/test-parse-expr.R
+++ b/tests/testthat/test-parse-expr.R
@@ -231,8 +231,8 @@ test_that("can parse compound expressions that involve stochastics", {
                              density = NULL,
                              mean = n * p)(n, p)))
   expect_equal(res$rhs$depends,
-               list(functions = c("Normal", "Binomial"),
-                    variables = character("n", "p")))
+               list(functions = c("+", "Normal", "Binomial"),
+                    variables = c("n", "p")))
   expect_true(res$rhs$is_stochastic)
 
   expect_identical(rewrite_stochastic_to_expectation(res$rhs$expr),

--- a/tests/testthat/test-zzz-gradient.R
+++ b/tests/testthat/test-zzz-gradient.R
@@ -5,8 +5,8 @@ test_that("can compute gradient", {
     N <- S + I + R
     p_inf <- beta * I / N * dt
     p_SI <- 1 - exp(-p_inf)
-    n_SI <- S * p_SI # Binomial(S, p_SI)
-    n_IR <- I * p_IR # Binomial(I, p_IR)
+    n_SI <- Binomial(S, p_SI)
+    n_IR <- Binomial(I, p_IR)
     update(S) <- S - n_SI
     update(I) <- I + n_SI - n_IR
     update(R) <- R + n_IR


### PR DESCRIPTION
This fixes a number of incomplete cases I introduced in #13:

* recursive calls were not properly dealt with
* we never substituted in the mean for the adjoints (I think this was due the other PR being in flight)
* fixes the name of the rng state when generating code (now covered by the integration test)