### PR TITLE
Add support for migrating stochastic calls

### DIFF
--- a/R/parse_compat.R
+++ b/R/parse_compat.R
@@ -121,7 +121,7 @@ parse_compat_report <- function(exprs, action, call) {
       updated <- vcapply(exprs[j], function(x) deparse1(x$value))
       original <- vcapply(exprs[j], function(x) deparse1(x$compat$original))
       context_t <- set_names(
-        c(rbind(updated, original, deparse.level = 0)),
+        c(rbind(original, updated, deparse.level = 0)),
         rep(c("x", "v"), length(updated)))
       detail <- c(detail, description[[t]], cli_nbsp(context_t))
     }

--- a/R/parse_compat.R
+++ b/R/parse_compat.R
@@ -2,10 +2,18 @@ parse_compat <- function(exprs, action, call) {
   ## Things we can translate:
   ##
   ## user() -> parameter()
+  
   ## rbinom() -> Binomial() [etc]
+  
   ## dt -> drop
   ## step -> time
+  ## t -> time
+
+  ## We also need to cope with the situation where we have three
+  ## things to fix in a single expression.
+  
   exprs <- lapply(exprs, parse_compat_fix_user, call)
+  exprs <- lapply(exprs, parse_compat_fix_distribution, call)
   parse_compat_report(exprs, action, call)
   exprs
 }
@@ -40,7 +48,54 @@ parse_compat_fix_user <- function(expr, call) {
       args <- c(args, list(res$value$default))
     }
     expr$value[[3]] <- as.call(args)
-    expr$compat <- list(type = "user", original = original)
+    expr <- parse_add_compat(expr, "user", original)
+  }
+  expr
+}
+
+
+parse_compat_fix_distribution <- function(expr, call) {
+  ## for most (or all) of these we can do a direct translation, the
+  ## args are unnamed.
+  translate <- c(
+    rbeta = quote(Beta),
+    rbinom = quote(Binomial),
+    rcauchy = quote(Cauchy),
+    rchisq = quote(ChiSquared),
+    rexp = quote(Exponential),
+    rf = quote(F),
+    rgamma = quote(Gamma),
+    rgeometric = quote(Geometric),
+    rhyper = quote(Hypergeometric),
+    rlogis = quote(Logistic),
+    rlnorm = quote(Lognormal),
+    rnbinom = quote(NegativeBinomial),
+    rnorm = quote(Normal),
+    rpois = quote(Poisson),
+    rt = quote(T),
+    runif = quote(Uniform),
+    rweibull = quote(Weibull),
+    ## Nonstandard interface
+    rmultinom = quote(Multinomial),
+    rmhyper = quote(MultivariateHypergeometric))
+
+  if (rlang::is_call(expr$value, c("<-", "="))) {
+    if (any(names(translate) %in% all.names(expr$value))) {
+      original <- expr$value
+      expr$value <- substitute_(expr$value, translate)
+      expr$compat <- list(type = "distribution", original = original)
+    }
+  }
+
+  expr
+}
+
+
+parse_add_compat <- function(expr, type, original) {
+  if (is.null(expr$compat)) {
+    expr$compat <- list(type = type, original = original)
+  } else {
+    expr$compat$type <- c(expr$compat$type, type)
   }
   expr
 }
@@ -50,12 +105,17 @@ parse_compat_report <- function(exprs, action, call) {
   i <- !vlapply(exprs, function(x) is.null(x$compat))
   if (action != "silent" && any(i)) {
     description <- c(
-      user = "Replace calls to 'user()' with 'parameter()'")
-    type <- vcapply(exprs[i], function(x) x$compat$type)
+      user = "Replace calls to 'user()' with 'parameter()'",
+      distribution = paste(
+        "Replace calls to r-style random number calls (e.g., 'rnorm()')",
+        "with mcstate2-stye calls (e.g., 'Normal()')"))
+
+    type <- lapply(exprs[i], function(x) x$compat$type)
+    err <- unlist0(type)
 
     detail <- NULL
-    for (t in intersect(names(description), type)) {
-      j <- i[type == t]
+    for (t in intersect(names(description), err)) {
+      j <- which(i)[vlapply(type, function(x) t %in% x)]
       ## Getting line numbers here is really hard, so let's just not
       ## try for now and do this on deparsed expressions.
       updated <- vcapply(exprs[j], function(x) deparse1(x$value))
@@ -66,7 +126,7 @@ parse_compat_report <- function(exprs, action, call) {
       detail <- c(detail, description[[t]], cli_nbsp(context_t))
     }
 
-    header <- "Found {sum(i)} compatibility issue{?s}"
+    header <- "Found {length(err)} compatibility issue{?s}"
 
     if (action == "error") {
       odin_parse_error(c(header, detail), "E1017", exprs[i], call)

--- a/R/parse_expr.R
+++ b/R/parse_expr.R
@@ -341,7 +341,6 @@ parse_expr_usage_rewrite_stochastic <- function(expr, src, call) {
 
   expr[[1]] <- call("OdinStochasticCall",
                     sample = res$value$cpp$sample,
-                    density = res$value$cpp$density,
                     mean = mean)
   expr[-1] <- args
   expr

--- a/tests/testthat/test-parse-compat.R
+++ b/tests/testthat/test-parse-compat.R
@@ -80,3 +80,16 @@ test_that("handle failure to pass a user call", {
     "Failed to translate your 'user()' expression to use 'parameter()'",
     fixed = TRUE)
 })
+
+
+test_that("can translate simple calls to distributions", {
+  expect_warning(
+    res <- odin_parse({
+      initial(a) <- 1
+      update(a) <- rnorm(a, 1)
+    }),
+    "Found 1 compatibility issue")
+  expect_equal(
+    res$phases$update$variables[[1]]$rhs$expr,
+    quote(OdinStochasticCall(sample = "normal", mean = a)(a, 1)))
+})

--- a/tests/testthat/test-parse-compat.R
+++ b/tests/testthat/test-parse-compat.R
@@ -23,6 +23,12 @@ test_that("can control severity of reporting", {
     "Found 1 compatibility issue")
 
   expect_true(startsWith(conditionMessage(e), conditionMessage(w)))
+  expect_equal(
+    e$body[2],
+    c(x = "a <- user(1)"))
+  expect_equal(
+    e$body[3],
+    c(v = "a <- parameter(1)"))
 })
 
 

--- a/tests/testthat/test-parse-expr.R
+++ b/tests/testthat/test-parse-expr.R
@@ -209,9 +209,7 @@ test_that("can parse expressions that involve stochastics", {
   expect_equal(res$lhs, list(name = "a"))
   expect_identical(
     res$rhs$expr,
-    quote(OdinStochasticCall(sample = "normal",
-                             density = "normal",
-                             mean = 0)(0, 1)))
+    quote(OdinStochasticCall(sample = "normal", mean = 0)(0, 1)))
   expect_equal(res$rhs$depends,
                list(functions = "Normal", variables = character()))
 })
@@ -222,14 +220,10 @@ test_that("can parse compound expressions that involve stochastics", {
 
   expect_identical(
     res$rhs$expr[[2]],
-    quote(OdinStochasticCall(sample = "normal",
-                             density = "normal",
-                             mean = 0)(0, 1)))
+    quote(OdinStochasticCall(sample = "normal", mean = 0)(0, 1)))
   expect_identical(
     res$rhs$expr[[3]],
-    quote(OdinStochasticCall(sample = "binomial",
-                             density = NULL,
-                             mean = n * p)(n, p)))
+    quote(OdinStochasticCall(sample = "binomial", mean = n * p)(n, p)))
   expect_equal(res$rhs$depends,
                list(functions = c("+", "Normal", "Binomial"),
                     variables = c("n", "p")))

--- a/tests/testthat/test-zzz-gradient.R
+++ b/tests/testthat/test-zzz-gradient.R
@@ -30,10 +30,10 @@ test_that("can compute gradient", {
                        has_adjoint = TRUE))
 
   time_start <- 0
-  time <- c(4, 8, 12, 16)
-  data <- lapply(1:4, function(i) list(cases_observed = i))
+  data <- data.frame(time = c(4, 8, 12, 16),
+                     cases_observed = 1:4)
 
-  obj <- dust2::dust_unfilter_create(sir(), time_start, time, data)
+  obj <- dust2::dust_unfilter_create(sir(), time_start, data)
   x <- c(beta = 0.1, gamma = 0.2, I0 = 10)
   ll <- dust2::dust_unfilter_run(obj, as.list(x), adjoint = TRUE)
   gr <- dust2::dust_unfilter_last_gradient(obj)


### PR DESCRIPTION
This PR adds support for migrating stochastic calls from the old form `rbinom()` etc to the new one (`Binomial()`).  I've put them all in even though we don't yet support everything because we can then fail better later once we add support for checking function usage.

A couple of minor tweaks:

* we no longer return density information with the `OdinStochasticCall` as that was never used
* we allow for the unlikely possibility of migrating both `user()` and the stochastic bits - this is more likely in the time bit of migration