### PR TITLE
Process source when building errors

### DIFF
--- a/R/migrate.R
+++ b/R/migrate.R
@@ -50,7 +50,8 @@ odin_migrate <- function(path, dest) {
       function(x) sprintf("[%s] %s", x$error$code, x$error$message))
     for (m in sort(msg)) {
       cli::cli_alert_danger(m)
-      for (line in format_src(exprs[is_error][msg == m])) {
+      src <- format_src(parse_error_src(exprs[is_error][msg == m]))
+      for (line in src) {
         cli::cli_text(line)
       }
     }

--- a/R/parse_system.R
+++ b/R/parse_system.R
@@ -292,14 +292,14 @@ parse_system_phases <- function(exprs, equations, variables, data, call) {
       required <- union(required, eqs[!is_time])
 
       if (phase %in% c("update", "deriv", "output")) {
-        check <- c(e, equations[eqs_time])
+        check <- c(e, unname(equations[eqs_time]))
         err <- lapply(check, function(eq) {
           intersect(data, eq$rhs$depends$variables)
         })
         is_err <- lengths(err) > 0
         if (any(is_err)) {
           data_err <- intersect(data, unlist0(err))
-          src <- lapply(check[is_err], "[[", "src")
+          src <- unname(lapply(check[is_err], "[[", "src"))
           odin_parse_error(
             c("Data may only be referenced from equations used in comparison",
               i = paste("You have referenced data {squote(data_err)} from",

--- a/tests/testthat/test-migrate.R
+++ b/tests/testthat/test-migrate.R
@@ -75,7 +75,8 @@ test_that("Write what we can, even if there are errors", {
   expect_match(res$messages[[1]], "Migrating 1 statement")
   expect_match(res$messages[[2]], "Skipped 1 statement")
   expect_match(res$messages[[3]], "Use of 'step' is no longer allowed")
-  expect_match(res$messages[[4]], "update(x)<- a + step", fixed = TRUE)
+  expect_match(cli::ansi_strip(res$messages[[4]]),
+               "update(x)<- a + step", fixed = TRUE)
   expect_match(res$messages[[5]], "This statement has been preserved")
 })
 

--- a/tests/testthat/test-parse-compat.R
+++ b/tests/testthat/test-parse-compat.R
@@ -34,20 +34,22 @@ test_that("can control severity of reporting", {
 
 test_that("can translate simple user calls", {
   expect_equal(
-    parse_compat_fix_user(list(value = quote(a <- user()))),
+    parse_compat_fix_user(list(value = quote(a <- user()), index = 1L)),
     list(value = quote(a <- parameter()),
+         index = 1L,
          compat = list(type = "user", original = quote(a <- user()))))
   expect_equal(
-    parse_compat_fix_user(list(value = quote(a <- user(1)))),
+    parse_compat_fix_user(list(value = quote(a <- user(1)), index = 1L)),
     list(value = quote(a <- parameter(1)),
+         index = 1L,
          compat = list(type = "user", original = quote(a <- user(1)))))
   expect_error(
-    parse_compat_fix_user(list(value = quote(a <- user(min = 0)))),
+    parse_compat_fix_user(list(value = quote(a <- user(min = 0)), index = 1L)),
     "Can't yet translate 'user()' calls that use the 'min' argument",
     fixed = TRUE,
     class = "odin_parse_error")
   expect_error(
-    parse_compat_fix_user(list(value = quote(a <- user(max = 1)))),
+    parse_compat_fix_user(list(value = quote(a <- user(max = 1)), index = 1L)),
     "Can't yet translate 'user()' calls that use the 'max' argument",
     fixed = TRUE,
     class = "odin_parse_error")

--- a/tests/testthat/test-parse.R
+++ b/tests/testthat/test-parse.R
@@ -52,13 +52,14 @@ test_that("throw error with context", {
     class = "odin_parse_error")
   expect_equal(
     err$src,
-    list(list(value = quote(b <- parameter(invalid = TRUE)),
-              index = 3,
-              start = 3,
-              end = 3,
-              str = c("b<-parameter(invalid=TRUE)"))))
+    data_frame(index = 3L,
+               expr = I(list(quote(b <- parameter(invalid = TRUE)))),
+               start = 3L,
+               end = 3L,
+               str = "b<-parameter(invalid=TRUE)",
+               migrated = FALSE))
   expect_match(
-    conditionMessage(err),
+    cli::ansi_strip(conditionMessage(err)),
     "Context:\n3| b<-parameter(invalid=TRUE)",
     fixed = TRUE)
 })
@@ -75,8 +76,16 @@ test_that("throw error with context where source code unavailable", {
     "Invalid call to 'parameter()'",
     fixed = TRUE,
     class = "odin_parse_error")
+  expect_equal(
+    err$src,
+    data_frame(index = 3L,
+               expr = I(list(quote(b <- parameter(invalid = TRUE)))),
+               start = NA_integer_,
+               end = NA_integer_,
+               str = NA_character_,
+               migrated = FALSE))
   expect_match(
-    conditionMessage(err),
+    cli::ansi_strip(conditionMessage(err)),
     "Context:\nb <- parameter(invalid = TRUE)",
     fixed = TRUE)
 })


### PR DESCRIPTION
This PR does some checking and processing of the `src` argument to `odin_parse_error` so that it is easier to work with.  We guarantee that context will be available and arrange the components in a data.frame; this will make https://github.com/mrc-ide/odin2/pull/58 nicer