### PR TITLE
Add support for user-sized arrays

### DIFF
--- a/R/parse_expr.R
+++ b/R/parse_expr.R
@@ -44,7 +44,7 @@ parse_expr_assignment <- function(expr, src, call) {
       odin_parse_error(
         paste("Invalid use of 'rank' argument in 'parameter()' call not",
               "assigning to dimension"),
-        "E1999", src, call)
+        "E1991", src, call)
     }
     special <- "parameter"
   } else if (rhs$type == "interpolate") {
@@ -243,7 +243,7 @@ parse_expr_assignment_rhs_dim <- function(rhs, src, call) {
     if (is.null(rhs$rank)) {
       odin_parse_error(
         "When using 'dim() <- parameter(...)', a 'rank' argument is required",
-        "E1999", src, call)
+        "E1992", src, call)
     }
     value <- vector("list", rhs$rank)
   } else if (rlang::is_call(rhs, "c")) {
@@ -390,7 +390,7 @@ parse_expr_assignment_rhs_parameter <- function(rhs, src, call) {
     if (!is_scalar_size(args$rank)) {
       odin_parse_error(
         "'rank' must be a scalar size, if given",
-        "E1999", src, call)
+        "E1993", src, call)
     }
   }
 

--- a/R/util.R
+++ b/R/util.R
@@ -59,6 +59,12 @@ is_scalar_character <- function(x) {
 }
 
 
+is_scalar_size <- function(x) {
+  is.numeric(x) && length(x) == 1 && !is.na(x) && rlang::is_integerish(x) &&
+    x > 0
+}
+
+
 collector <- function(init = character(0)) {
   env <- new.env(parent = emptyenv())
   env$res <- init

--- a/tests/testthat/test-generate.R
+++ b/tests/testthat/test-generate.R
@@ -1559,3 +1559,47 @@ test_that("can interpolate arrays", {
       "  state_next[0] = x + dust2::array::sum<real_type>(internal.a, shared.dim.a);",
       "}"))
 })
+
+
+test_that("can generate user-sized arrays", {
+  dat <- odin_parse({
+    initial(x) <- 1
+    update(x) <- x + sum(a)
+    a <- parameter()
+    dim(a) <- parameter(rank = 1)
+  })
+
+  dat <- generate_prepare(dat)
+
+  expect_equal(
+    generate_dust_system_shared_state(dat),
+    c("struct shared_state {",
+      "  struct dim_type {",
+      "    dust2::array::dimensions<1> a;",
+      "  } dim;",
+      "  struct offset_type {",
+      "    struct {",
+      "      size_t x;",
+      "    } state;",
+      "  } offset;",
+      "  std::vector<real_type> a;",
+      "};"))
+
+  expect_equal(
+    generate_dust_system_build_shared(dat),
+      c(method_args$build_shared,
+        '  const auto dim_a = read_dimensions<1>(parameters, "a");',
+        "  std::vector<real_type> a(dim_a.size);",
+        '  dust2::r::read_real_array(parameters, dim_a, a.data(), "a", true);',
+        "  const shared_state::dim_type dim{dim_a};",
+        "  shared_state::offset_type offset;",
+        "  offset.state.x = 0;",
+        "  return shared_state{dim, offset, a};",
+        "}"))
+
+  expect_equal(
+    generate_dust_system_update_shared(dat),
+    c(method_args$update_shared,
+      '  dust2::r::read_real_array(parameters, shared.dim.a, shared.a.data(), "a", false);',
+      "}"))
+})

--- a/tests/testthat/test-parse-compat.R
+++ b/tests/testthat/test-parse-compat.R
@@ -248,3 +248,30 @@ test_that("Fix use of 'step' in equations", {
     }),
     "Use of 'step' is no longer allowed")
 })
+
+
+test_that("fix user-sized arrays", {
+  expect_warning(
+    res <- odin_parse({
+      a[, ] <- user()
+      dim(a) <- user()
+      update(x) <- x + sum(a)
+      initial(x) <- 0
+    }),
+    "Found 4 compatibility issues")
+  expect_equal(res$equations$dim_a$src$value,
+               quote(dim(a) <- parameter(rank = 2)))
+  expect_equal(res$storage$arrays$rank, 2)
+})
+
+
+test_that("error where we can't determine rank in migration", {
+  expect_error(
+    odin_parse({
+      dim(a) <- user()
+      update(x) <- x + sum(a)
+      initial(x) <- 0
+    }),
+    "Can't determine rank for 'dim() <- user()' call",
+    fixed = TRUE)
+})

--- a/tests/testthat/test-parse-expr.R
+++ b/tests/testthat/test-parse-expr.R
@@ -424,3 +424,29 @@ test_that("Can't assign to names with reserved prefixes", {
   expect_error(parse_expr(quote(adjoint_x <- 1), NULL, NULL),
                "Invalid name 'adjoint_x' starts with reserved prefix 'adjoint'")
 })
+
+
+test_that("can parse user-sized arrays", {
+  res <- parse_expr(quote(dim(x) <- parameter(rank = 1)), NULL, NULL)
+  expect_equal(res$rhs$value, list(NULL))
+  expect_true(res$rhs$is_user_sized)
+  res <- parse_expr(quote(dim(x) <- parameter(rank = 3)), NULL, NULL)
+  expect_equal(res$rhs$value, list(NULL, NULL, NULL))
+  expect_true(res$rhs$is_user_sized)
+})
+
+
+test_that("require a rank argument if arrays are user sized", {
+  expect_error(
+    parse_expr(quote(dim(x) <- parameter()), NULL, NULL),
+    "When using 'dim() <- parameter(...)', a 'rank' argument is required",
+    fixed = TRUE)
+})
+
+
+test_that("require that rank argument is missing generally for parameters", {
+  expect_error(
+    parse_expr(quote(a <- parameter(rank = 4)), NULL, NULL),
+    "Invalid use of 'rank' argument in 'parameter()'",
+    fixed = TRUE)
+})

--- a/vignettes/errors.Rmd
+++ b/vignettes/errors.Rmd
@@ -702,6 +702,22 @@ with the value of the `rank` argument being a literal integer.  See `vignette("f
 
 Invalid value for `rank` argument to `parameter()`.  Where given it must be a positive size; literally an integer value of 1, 2, 3, ..., 8.  You cannot use a variable here.
 
+# `E1994`
+
+Failed to migrate expression of form
+
+```r
+dim(a) <- user()
+```
+
+because we never found an assignment like
+
+```
+a[] <- user()
+```
+
+where we could determine the rank.  This might be because you've removed the square brackets from the original, or the original assignment is simply missing.  If your code does compile with odin1 but you see this error code please let us know.
+
 # `E2001`
 
 Your system of equations does not include any expressions with `initial()` on the lhs.  This is what we derive the set of variables from, so at least one must be present.

--- a/vignettes/errors.Rmd
+++ b/vignettes/errors.Rmd
@@ -671,6 +671,37 @@ a <- parameter(c(1, 2, 3))
 
 to have a default value of vector of 1:3; however this is quite hard to validate and generalises poorly to higher dimensions.  Your thoughts and use-cases are very welcome.
 
+# `E1991`
+
+Invalid use of `rank` argument to `parameter()` call that does not assign to dimensions.  You might have written
+
+```
+a <- parameter(rank = 2)
+```
+
+but this is not the place to include the `rank` argument.  Instead, it should go onto the call with `dim(a)` on the left-hand-side.
+
+
+# `E1992`
+
+Missing `rank` argument to call to `parameter()` which assigns to `dim()`.  You may have written
+
+```
+dim(a) <- parameter()
+```
+
+but here we need to know what rank `a` is (is it a vector, matrix, etc).  You can fix this by writing
+
+```
+dim(a) <- parameter(rank = 2)
+```
+
+with the value of the `rank` argument being a literal integer.  See `vignette("functions")` for more information on this interface.
+
+# `E1993`
+
+Invalid value for `rank` argument to `parameter()`.  Where given it must be a positive size; literally an integer value of 1, 2, 3, ..., 8.  You cannot use a variable here.
+
 # `E2001`
 
 Your system of equations does not include any expressions with `initial()` on the lhs.  This is what we derive the set of variables from, so at least one must be present.

--- a/vignettes/functions.Rmd
+++ b/vignettes/functions.Rmd
@@ -292,6 +292,7 @@ The function `parameter()` introduces a "parameter"; something that you will ini
 * `constant`: Logical, indicating if the parameter cannot be changed after being initially set.  This must be `TRUE` for things leading into array extents
 * `differentiate`: Logical, indicating if the likelihood (from comparison to data) should be differentiated with respect to this parameter.
 * `type`: The data type for the variable, as a string.  Must be one of `real` (the default), `integer` or `logical`.
+* `rank`: The number of dimensions of the parameter.  This is only used when assigning to `dim()` (see below)
 
 For example:
 
@@ -310,6 +311,15 @@ There are some interactions among the `differentiate` argument combined with `co
 * If a parameter is differentiable (`differentiate = TRUE`) it may not be constant!
 * If **any** parameter is differentiable, the default value for `constant` is `TRUE`, and all non-constant parameters must be differentiable.  Otherwise the default value for `constant` is `FALSE`
 * Only parameters with `type = "real"` can be used with `differentiate = TRUE`
+
+If your parameter has its dimensions determined by the size data you give it, you need to write it slightly specially:
+
+```
+a <- parameter()
+dim(a) <- parameter(rank = 2)
+```
+
+The `rank` argument here is required because otherwise we have no information on the number of dimensions that `a` has; here by saying `rank = 2` we specify that `a` is a matrix.  *We might change this interface in future, the implementation here fairly closely matches that in odin1.*
 
 ## Data
 

--- a/vignettes/migrating.Rmd
+++ b/vignettes/migrating.Rmd
@@ -122,6 +122,29 @@ dim(a) <- 10
 
 which makes it clearer that **all** of `a` is assigned by the parameter call.
 
+## Vector/matrix/array parameters whose size is determined by input require `rank` argument
+
+What a mouthful.  Previously you might have written
+
+```r
+a[, ] <- user()
+dim(a) <- user()
+```
+
+which means "`a` is a matrix whose dimensions are determined by the input we are given on initialisation".  Because of the previous change the first line changes to
+
+```r
+a <- parameter()
+```
+
+but that means that we no longer know that `a` has two dimensions.  That's ok because we've moved the responsibility for this into the `dim()` assignment line anyway (internally).  So for now you write
+
+```r
+dim(a) <- parameter(rank = 2)
+```
+
+which conveys the same intent.  We may make this slightly more friendly in future (see `vignette("functions")`).
+
 ## Discrete-time models have a more solid time basis
 
 Previously, discrete time models used `step` to count steps forward as unsigned integers, usually from zero.  Many models added a parameter (or constant) `dt` representing the timestep and then a variable `time` which represented the time as a real-valued number.  For example you might have `dt` of 0.25 and then your model stops at times `[0, 0.25, 0.5, 0.75, 1]` for steps `[0, 1, 2, 3, 4]`.


### PR DESCRIPTION
The last of the big array bits I think, aside from validation.

This allows the extent of the array to be determined by the size of the object passed in by the user; this is made fairly straightforward by the utilities in dust (https://github.com/mrc-ide/dust2/pull/74).

For now, we use

```
a <- parameter()
dim(a) <- parameter(rank = 2)
```

I don't love this, and we might want to change it in future.  However, it's very similar to odin's previous

```
a[, ] <- user()
dim(a) <- user()
```

we may need to provide some additional migration help here.

In future, what might be nicer is something like

```
dim(a) <- parameter(c(NA, NA))
```

for the above case, which would generalise to allow

```
dim(a) <- parameter(c(2, NA))
```

for a 2-row matrix whose third dimension is determined by the parameter given.  Something for later though (cc: @edknock)