### PR TITLE
Disallow use of index variables in non-array equations

### DIFF
--- a/R/parse_expr.R
+++ b/R/parse_expr.R
@@ -70,7 +70,7 @@ parse_expr_assignment <- function(expr, src, call) {
   index_used <- intersect(INDEX, rhs$depends$variables)
   if (length(index_used) > 0) {
     n <- length(lhs$array)
-    err <- intersect(index_used, INDEX[-seq_len(n)])
+    err <- if (n == 0) index_used else intersect(index_used, INDEX[-seq_len(n)])
     if (length(err) > 0) {
       v <- err[length(err)]
       i <- match(v, INDEX)

--- a/tests/testthat/test-parse-expr-array.R
+++ b/tests/testthat/test-parse-expr-array.R
@@ -59,6 +59,9 @@ test_that("can't use array access with higher rank than the lhs implies", {
   expect_error(
     parse_expr(quote(a[] <- x[j]), NULL, NULL),
     "Invalid index access used on rhs of equation: 'j'")
+  expect_error(
+    parse_expr(quote(a <- x + k), NULL, NULL),
+    "Invalid index access used on rhs of equation: 'k'")
 })
 
 


### PR DESCRIPTION
Small parse error that I noticed while writing docs...