### PR TITLE
Allow odin_show to only show some methods

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: odin2
 Title: Next generation odin
-Version: 0.1.4
+Version: 0.1.5
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Imperial College of Science, Technology and Medicine",

--- a/R/generate_dust.R
+++ b/R/generate_dust.R
@@ -12,24 +12,33 @@ generate_dust_system <- function(dat) {
   }
   body$add("  using real_type = double;")
   body$add("  using rng_state_type = monty::random::generator<real_type>;")
-  body$add(sprintf("  %s", generate_dust_system_shared_state(dat)))
-  body$add(sprintf("  %s", generate_dust_system_internal_state(dat)))
-  body$add(sprintf("  %s", generate_dust_system_data_type(dat)))
-  body$add(sprintf("  %s", generate_dust_system_packing_state(dat)))
-  body$add(sprintf("  %s", generate_dust_system_packing_gradient(dat)))
-  body$add(sprintf("  %s", generate_dust_system_build_shared(dat)))
-  body$add(sprintf("  %s", generate_dust_system_build_internal(dat)))
-  body$add(sprintf("  %s", generate_dust_system_build_data(dat)))
-  body$add(sprintf("  %s", generate_dust_system_update_shared(dat)))
-  body$add(sprintf("  %s", generate_dust_system_update_internal(dat)))
-  body$add(sprintf("  %s", generate_dust_system_initial(dat)))
-  body$add(sprintf("  %s", generate_dust_system_update(dat)))
-  body$add(sprintf("  %s", generate_dust_system_rhs(dat)))
-  body$add(sprintf("  %s", generate_dust_system_zero_every(dat)))
-  body$add(sprintf("  %s", generate_dust_system_compare_data(dat)))
-  body$add(sprintf("  %s", generate_dust_system_adjoint(dat)))
+  parts <- generate_dust_parts()
+  for (nm in names(parts)) {
+    body$add(sprintf("  %s", parts[[nm]](dat)))
+  }
   body$add("};")
   body$get()
+}
+
+
+generate_dust_parts <- function() {
+  list(
+    shared_state = generate_dust_system_shared_state,
+    internal_state = generate_dust_system_internal_state,
+    data_type = generate_dust_system_data_type,
+    packing_state = generate_dust_system_packing_state,
+    packing_gradient = generate_dust_system_packing_gradient,
+    build_shared = generate_dust_system_build_shared,
+    build_internal = generate_dust_system_build_internal,
+    build_data = generate_dust_system_build_data,
+    update_shared = generate_dust_system_update_shared,
+    update_internal = generate_dust_system_update_internal,
+    initial = generate_dust_system_initial,
+    update = generate_dust_system_update,
+    rhs = generate_dust_system_rhs,
+    zero_every = generate_dust_system_zero_every,
+    compare_data = generate_dust_system_compare_data,
+    adjoint = generate_dust_system_adjoint)
 }
 
 

--- a/R/odin.R
+++ b/R/odin.R
@@ -54,6 +54,20 @@ odin <- function(expr, input_type = NULL, quiet = NULL, workdir = NULL,
 ##'   but the model lacks this part.
 ##'
 ##' @export
+##' @examples
+##' # Show generated code for the whole system
+##' odin_show({
+##'   initial(x) <- 1
+##'   update(x) <- a
+##'   a <- Normal(x, 1)
+##' })
+##'
+##' # Just the update method
+##' odin_show({
+##'   initial(x) <- 1
+##'   update(x) <- a
+##'   a <- Normal(x, 1)
+##' }, what = "update")
 odin_show <- function(expr, input_type = NULL, compatibility = "warning",
                       what = NULL) {
   call <- environment()

--- a/man/odin.Rd
+++ b/man/odin.Rd
@@ -27,7 +27,9 @@ beneficial in programmatic environments.}
 
 \item{quiet}{Logical, indicating if compilation messages from
 \code{pkgbuild} should be displayed.  Error messages will be
-displayed on compilation failure regardless of the value used.}
+displayed on compilation failure regardless of the value used.
+If \code{NULL} is given, then we take the value from \code{DUST_QUIET} if set, or
+\code{FALSE} otherwise.}
 
 \item{workdir}{Optional working directory to use.  If \code{NULL}, the
 behaviour depends on the existence of the environment variable

--- a/man/odin_package.Rd
+++ b/man/odin_package.Rd
@@ -12,7 +12,9 @@ odin_package(path, quiet = FALSE, compatibility = "warning")
 
 \item{quiet}{Logical, indicating if compilation messages from
 \code{pkgbuild} should be displayed.  Error messages will be
-displayed on compilation failure regardless of the value used.}
+displayed on compilation failure regardless of the value used.
+If \code{NULL} is given, then we take the value from \code{DUST_QUIET} if set, or
+\code{FALSE} otherwise.}
 
 \item{compatibility}{Compatibility mode to use.  Valid options are
 "warning", which updates code that can be fixed, with warnings,

--- a/man/odin_show.Rd
+++ b/man/odin_show.Rd
@@ -4,7 +4,7 @@
 \alias{odin_show}
 \title{Show generated odin code}
 \usage{
-odin_show(expr, input_type = NULL, compatibility = "warning")
+odin_show(expr, input_type = NULL, compatibility = "warning", what = NULL)
 }
 \arguments{
 \item{expr}{Odin code as the path to a file (a string), a
@@ -24,10 +24,14 @@ silently rewrite code, but this is not recommended for general
 use as eventually the compatibility mode will be removed (this
 option is primarily intended for comparing output of odin1 and
 odin2 models against old code).}
+
+\item{what}{Optional string, being a single method to show.
+Popular options are \code{update}, \code{rhs} and \code{compare_data}.}
 }
 \value{
 A character vector, with class \code{odin_code} that has a
-pretty-print method defined.
+pretty-print method defined.  Returns \code{NULL} if \code{what} was given
+but the model lacks this part.
 }
 \description{
 Show generated code from compiling an odin model.

--- a/man/odin_show.Rd
+++ b/man/odin_show.Rd
@@ -36,3 +36,18 @@ but the model lacks this part.
 \description{
 Show generated code from compiling an odin model.
 }
+\examples{
+# Show generated code for the whole system
+odin_show({
+  initial(x) <- 1
+  update(x) <- a
+  a <- Normal(x, 1)
+})
+
+# Just the update method
+odin_show({
+  initial(x) <- 1
+  update(x) <- a
+  a <- Normal(x, 1)
+}, what = "update")
+}

--- a/scripts/bump_version
+++ b/scripts/bump_version
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -eu
+
+ACTION="${1:-patch}"
+CURRENT_VERSION=$(grep '^Version' DESCRIPTION  | sed 's/.*: *//')
+MAJOR=$(echo $CURRENT_VERSION | cut -d. -f1)
+MINOR=$(echo $CURRENT_VERSION | cut -d. -f2)
+PATCH=$(echo $CURRENT_VERSION | cut -d. -f3)
+echo "Current version: ${CURRENT_VERSION}"
+
+if [ $# -gt 1 ]; then
+  echo "Invalid args"
+  exit 1
+fi
+
+case $ACTION in
+    reset)
+        echo "Resetting version"
+        LAST_VERSION=$(git show origin/main:DESCRIPTION | grep '^Version' | sed 's/.*: *//')
+        MAJOR=$(echo $LAST_VERSION | cut -d. -f1)
+        MINOR=$(echo $LAST_VERSION | cut -d. -f2)
+        PATCH=$(echo $LAST_VERSION | cut -d. -f3)
+    ;;
+    major)
+        echo "Updating major version"
+        MAJOR=$(($MAJOR + 1))
+        MINOR=0
+        PATCH=0
+        ;;
+    minor)
+        echo "Updating minor version"
+        MINOR=$(($MINOR + 1))
+        PATCH=0
+        ;;
+    patch)
+        echo "Updating patch version"
+        PATCH=$(($PATCH + 1))
+        ;;
+    *)
+        if echo "$ACTION" | grep -Eq "[0-9]+[.][0-9]+[.][0-9]+"; then
+            echo "Updating version directly"
+            MAJOR=$(echo $VERSION | cut -d. -f1)
+            MINOR=$(echo $VERSION | cut -d. -f2)
+            PATCH=$(echo $VERSION | cut -d. -f3)
+        else
+            echo "[ERROR] Invalid format version number '$VERSION' must be in format 'x.y.z'"
+            exit 1
+        fi
+        ;;
+esac
+
+NEXT_VERSION="${MAJOR}.${MINOR}.${PATCH}"
+echo "Updating to version: ${NEXT_VERSION}"
+
+sed -i "s/^Version: .*$/Version: ${NEXT_VERSION}/" DESCRIPTION

--- a/tests/testthat/test-show.R
+++ b/tests/testthat/test-show.R
@@ -15,3 +15,15 @@ test_that("can print odin_code", {
   expect_match(res$messages, "odin code:", all = FALSE)
   expect_equal(res$output, paste(code, collapse = "\n"))
 })
+
+
+test_that("can generate code", {
+  res <- odin_show({
+    initial(x) <- 1
+    update(x) <- x + 1
+  }, what = "update")
+  expect_s3_class(res, "odin_code")
+  expect_type(res, "character")
+  res <- evaluate_promise(print(res))
+  expect_match(res$messages, "odin code (update):", all = FALSE, fixed = TRUE)
+})


### PR DESCRIPTION
This might be useful in the docs, particularly when discussing arrays.

Also added a bump version script