### PR TITLE
Fix interpolation parsing

### DIFF
--- a/R/parse_expr.R
+++ b/R/parse_expr.R
@@ -48,7 +48,7 @@ parse_expr_assignment <- function(expr, src, call) {
     }
     special <- "parameter"
   } else if (rhs$type == "interpolate") {
-    if (!is.null(special)) {
+    if (!is.null(special) || !is.null(lhs$array)) {
       odin_parse_error(
         "Calls to 'interpolate()' must be assigned to a symbol",
         "E1037", src, call)

--- a/R/parse_system.R
+++ b/R/parse_system.R
@@ -105,20 +105,20 @@ parse_system_overall <- function(exprs, call) {
       rank_result <- get_rank(nm_result)
 
       if (get_rank(nm_time) != 1L) {
-        cli::cli_abort(
+        odin_parse_error(
           c(paste("Expected time argument '{nm_time}' to 'interpolate()' for",
-                  "{nm_result}' to be a vector"),
+                  "'{nm_result}' to be a vector"),
             i = "{nm_time} was a {rank_description(get_rank(nm_time))}"),
-          "E2015", src, call)
+          "E2015", eq$src, call)
       }
       rank_value_expected <- 1L + rank_result
       if (get_rank(nm_value) != rank_value_expected) {
-        cli::cli_abort(
+        odin_parse_error(
           c(paste("Expected value argument '{nm_value}' to 'interpolate()' for",
-                  "{nm_result}' to be a",
+                  "'{nm_result}' to be a",
                   "{rank_description(rank_value_expected)}"),
             i = "{nm_value} was a {rank_description(get_rank(nm_value))}"),
-          "E2015", src, call)
+          "E2015", eq$src, call)
       }
 
       ## TODO: we could warn here about things that look incompatible,

--- a/tests/testthat/test-parse-compat.R
+++ b/tests/testthat/test-parse-compat.R
@@ -275,3 +275,22 @@ test_that("error where we can't determine rank in migration", {
     "Can't determine rank for 'dim() <- user()' call",
     fixed = TRUE)
 })
+
+
+test_that("disallow parsing interpolation to slice", {
+  w <- expect_warning(
+    odin_parse({
+      a <- parameter()
+      dim(a) <- 10
+      b <- parameter()
+      dim(b) <- c(3, 10)
+      v[] <- interpolate(a, b, "constant")
+      update(x) <- sum(v)
+      initial(x) <- 0
+      dim(v) <- 3
+    }),
+    "Found 1 compatibility issue")
+  expect_match(conditionMessage(w),
+               "Drop arrays from lhs of assignments from 'interpolate()'",
+               fixed = TRUE)
+})

--- a/tests/testthat/test-parse-expr-interpolate.R
+++ b/tests/testthat/test-parse-expr-interpolate.R
@@ -48,3 +48,11 @@ test_that("parse interpolation call", {
     list(functions = character(),
          variables = c("a", "b")))
 })
+
+
+test_that("prevent use of assignment into slice for interpolate", {
+  expect_error(
+    parse_expr(quote(a[] <- interpolate(x, y, "constant")), NULL, NULL),
+    "Calls to 'interpolate()' must be assigned to a symbol",
+    fixed = TRUE)
+})

--- a/tests/testthat/test-parse.R
+++ b/tests/testthat/test-parse.R
@@ -489,3 +489,36 @@ test_that("Don't allow vectors to have defaults", {
     }),
     "Array parameters cannot have defaults")
 })
+
+
+
+
+test_that("check rank of interpolate assignment", {
+  expect_error(
+    odin_parse({
+      a <- parameter()
+      dim(a) <- 10
+      b <- parameter()
+      dim(b) <- c(3, 10)
+      v <- interpolate(a, b, "constant")
+      update(x) <- sum(v)
+      initial(x) <- 0
+    }),
+    "Expected value argument 'b' to 'interpolate()' for 'v' to be a vector",
+    fixed = TRUE)
+})
+
+
+test_that("check rank of interpolate time arg", {
+  expect_error(
+    odin_parse({
+      a <- parameter()
+      b <- parameter()
+      dim(b) <- 10
+      v <- interpolate(a, b, "constant")
+      update(x) <- sum(v)
+      initial(x) <- 0
+    }),
+    "Expected time argument 'a' to 'interpolate()' for 'v' to be a vector",
+    fixed = TRUE)
+})

--- a/vignettes/migrating.Rmd
+++ b/vignettes/migrating.Rmd
@@ -147,7 +147,7 @@ which conveys the same intent.  We may make this slightly more friendly in futur
 
 ## Interpolate results assign without array indices
 
-Previously, if you had an `interpolate()` call that returned a vector (or higher-dimension array) you you had to write
+Previously, if you had an `interpolate()` call that returned a vector (or higher-dimension array) you had to write
 
 ```r
 v[] <- interpolate(a, b, "constant")

--- a/vignettes/migrating.Rmd
+++ b/vignettes/migrating.Rmd
@@ -145,6 +145,20 @@ dim(a) <- parameter(rank = 2)
 
 which conveys the same intent.  We may make this slightly more friendly in future (see `vignette("functions")`).
 
+## Interpolate results assign without array indices
+
+Previously, if you had an `interpolate()` call that returned a vector (or higher-dimension array) you you had to write
+
+```r
+v[] <- interpolate(a, b, "constant")
+```
+
+but now you should drop the `[]`, as for the `parameter()` case above, as you are replacing *all* of `v` at once, writing:
+
+```r
+v <- interpolate(a, b, "constant")
+```
+
 ## Discrete-time models have a more solid time basis
 
 Previously, discrete time models used `step` to count steps forward as unsigned integers, usually from zero.  Many models added a parameter (or constant) `dt` representing the timestep and then a variable `time` which represented the time as a real-valued number.  For example you might have `dt` of 0.25 and then your model stops at times `[0, 0.25, 0.5, 0.75, 1]` for steps `[0, 1, 2, 3, 4]`.


### PR DESCRIPTION
* Adds an error documented to be thrown, but was not (assignment to array)
* Adds migration which hides the previous error most of the time
* Tests and fixes two rank checks that were erroring while throwing an error

~Merge after #73, contains that commit~