### PR TITLE
Fix dependency calculation in multiline arrays

### DIFF
--- a/R/parse_system.R
+++ b/R/parse_system.R
@@ -214,9 +214,10 @@ parse_system_depends <- function(equations, variables, call) {
   for (i in seq_along(deps)) {
     nm <- names(deps)[[i]]
     vars <- deps[[i]]
-    deps_recursive[[nm]] <- union(
+    deps_recursive[[nm]] <- unique(c( # union, but for 3 args...
+      deps_recursive[[nm]],
       vars,
-      unlist(deps_recursive[vars], FALSE, FALSE))
+      unlist(deps_recursive[vars], FALSE, FALSE)))
   }
 
   for (nm in names(deps_recursive)) {

--- a/R/parse_system.R
+++ b/R/parse_system.R
@@ -211,11 +211,15 @@ parse_system_depends <- function(equations, variables, call) {
     setdiff(eq$rhs$depends$variables, automatic)
   })
   deps_recursive <- list()
-  for (nm in names(deps)) {
-    vars <- deps[[nm]]
+  for (i in seq_along(deps)) {
+    nm <- names(deps)[[i]]
+    vars <- deps[[i]]
     deps_recursive[[nm]] <- union(
       vars,
       unlist(deps_recursive[vars], FALSE, FALSE))
+  }
+
+  for (nm in names(deps_recursive)) {
     for (i in which(names(equations) == nm)) {
       equations[[i]]$rhs$depends$variables_recursive <- deps_recursive[[nm]]
     }

--- a/tests/testthat/test-parse-system.R
+++ b/tests/testthat/test-parse-system.R
@@ -200,3 +200,18 @@ test_that("detect dependencies correctly across multline arrays", {
   expect_equal(dat$phases$update$equations, "a")
   expect_equal(dat$phases$build_shared$equations, c("b", "dim_a"))
 })
+
+
+test_that("detect dependencies correctly across multline arrays", {
+  dat <- odin_parse({
+    a[] <- c
+    a[1] <- b * time
+    b <- parameter()
+    c <- parameter()
+    initial(x) <- 0
+    update(x) <- sum(a)
+    dim(a) <- 3
+  })
+  expect_equal(dat$phases$update$equations, "a")
+  expect_equal(dat$phases$build_shared$equations, c("b", "c", "dim_a"))
+})

--- a/tests/testthat/test-parse-system.R
+++ b/tests/testthat/test-parse-system.R
@@ -186,3 +186,17 @@ test_that("Error if equations unused", {
     }),
     "Unused equations: 'x' and 'b'")
 })
+
+
+test_that("detect dependencies correctly across multline arrays", {
+  dat <- odin_parse({
+    a[] <- 0
+    a[1] <- b * time
+    b <- parameter()
+    initial(x) <- 0
+    update(x) <- sum(a)
+    dim(a) <- 3
+  })
+  expect_equal(dat$phases$update$equations, "a")
+  expect_equal(dat$phases$build_shared$equations, c("b", "dim_a"))
+})


### PR DESCRIPTION
~Merge after #74, contains those commits~

I was not correctly collecting recursive dependencies in a multline array case - see the tests.  If you try and run these tests from main you'll get errors about variables not being used, when they obviously are.