### PR TITLE
Use monty math for min/max

### DIFF
--- a/R/constants.R
+++ b/R/constants.R
@@ -8,6 +8,8 @@ FUNCTIONS_MONTY_MATH <-
   c("^" = "pow",
     "%%" = "fmod",
     "%/%" = "fintdiv",
+    min = "min",
+    max = "max",
     ceiling = "ceil",
     sign = "sign",
     floor = "floor",

--- a/R/generate_dust_sexp.R
+++ b/R/generate_dust_sexp.R
@@ -113,6 +113,13 @@ generate_dust_sexp <- function(expr, dat, options = list()) {
       ## into monty's math library, but for now this is ok.
       ret <- sprintf("std::fmod(%s, %s)", args_str[[1]], args_str[[2]])
     } else if (fn %in% names(FUNCTIONS_MONTY_MATH)) {
+      if (fn %in% c("min", "max")) {
+        is_integer_like <- grepl("^[0-9]$", args_str)
+        if (any(is_integer_like) && !all(is_integer_like)) {
+          args_str[is_integer_like] <- sprintf("static_cast<real_type>(%s)",
+                                               args_str[is_integer_like])
+        }
+      }
       ret <- sprintf("monty::math::%s(%s)",
                      FUNCTIONS_MONTY_MATH[[fn]],
                      paste(args_str, collapse = ", "))
@@ -120,13 +127,6 @@ generate_dust_sexp <- function(expr, dat, options = list()) {
       ret <- sprintf("static_cast<real_type>(%s)", args_str[[1]])
     } else if (fn == "as.integer") {
       ret <- sprintf("static_cast<int>(%s)", args_str[[1]])
-    } else if (fn %in% c("min", "max")) {
-      is_integer_like <- grepl("^[0-9]$", args_str)
-      if (any(is_integer_like) && !all(is_integer_like)) {
-        args_str[is_integer_like] <- sprintf("static_cast<real_type>(%s)",
-                                             args_str[is_integer_like])
-      }
-      ret <- sprintf("std::%s(%s)", fn, paste(args_str, collapse = ", "))
     } else if (fn == "if") {
       ## NOTE: The ternary operator has very low precendence, so we
       ## will agressively parenthesise it.  This is strictly not

--- a/tests/testthat/test-generate-dust-sexp.R
+++ b/tests/testthat/test-generate-dust-sexp.R
@@ -18,11 +18,11 @@ test_that("can generate min/max expressions", {
   dat <- generate_dust_dat(c(a = "shared", b = "stack"), NULL, NULL, NULL)
   options <- list()
   expect_equal(generate_dust_sexp(quote(min(a, b)), dat, options),
-               "std::min(shared.a, b)")
+               "monty::math::min(shared.a, b)")
   expect_equal(generate_dust_sexp(quote(max(a, 1)), dat, options),
-               "std::max(shared.a, static_cast<real_type>(1))")
+               "monty::math::max(shared.a, static_cast<real_type>(1))")
   expect_equal(generate_dust_sexp(quote(min(2, 1)), dat, options),
-               "std::min(2, 1)")
+               "monty::math::min(2, 1)")
 })
 
 

--- a/tests/testthat/test-generate.R
+++ b/tests/testthat/test-generate.R
@@ -1675,7 +1675,7 @@ test_that("support min/max", {
   expect_equal(
     generate_dust_system_update(dat),
     c(method_args$update,
-      "  state_next[0] = dust2::array::min<real_type>(shared.a.data(), shared.dim.a) + std::max(shared.b, shared.c);",
+      "  state_next[0] = dust2::array::min<real_type>(shared.a.data(), shared.dim.a) + monty::math::max(shared.b, shared.c);",
       "}"))
 })
 


### PR DESCRIPTION
We do this for the reduction form anyway, but this uses `monty::math::min` in place of `std::min`.  They have different behaviour for NaNs that we will need to explore later, but at least this way is the same behaviour as for odin.dust