### PR TITLE
mrc-5894 - fix some reported array index issues

### DIFF
--- a/R/generate_dust.R
+++ b/R/generate_dust.R
@@ -598,7 +598,10 @@ array_rewrite_index <- function(expr, src, dest) {
     if (is.recursive(expr[[e]])) {
       expr[[e]] <- array_rewrite_index(expr[[e]], src, dest)
     } else if (is.symbol(expr[[e]]) && (as.character(expr[[e]]) == src)) {
-      expr[[e]] <- as.symbol(dest)
+      if (is.character(dest)) {
+        dest <- as.symbol(dest)
+      }
+      expr[[e]] <- dest
     }
   }
   expr
@@ -687,8 +690,8 @@ generate_dust_assignment <- function(eq, name_state, dat, options = list()) {
         } else {          # idx$type == "single"
           
           # We need to replace [i,j,k....] on the right hand side with
-          # the matching var inside the array[...] on the left.
-          
+          # the matching var (or value) in the array[a,4,b] on the left.
+
           lhs_index <- which(unlist(lapply(eq$lhs$array, function(x) {
             x$name == idx$name})))
           lhs_var <- eq$lhs$array[[lhs_index]]$at

--- a/R/parse_system.R
+++ b/R/parse_system.R
@@ -185,12 +185,13 @@ parse_array_range_depends <- function(x) {
     if (is.symbol(x)) {
       return(as.character(x))
     } else if (is.call(x)) {
-      return(find_dependencies(x)$variables)
-    } else if (as.character(x[[1]]) %in% c("OdinDim", "length")) {
-      if (!is.numeric(x[[2]])) {
-        return(as.character(x[[2]]))
+      if (as.character(x[[1]]) %in% c("OneDim", "length")) {
+        if (!is.numeric(x[[2]])) {
+          return(as.character(x[[2]]))
+        }
       }
-    }
+      return(find_dependencies(x)$variables)
+    } 
   }
 }
 

--- a/R/parse_system.R
+++ b/R/parse_system.R
@@ -187,7 +187,15 @@ parse_system_depends <- function(equations, variables, call) {
   ## First, compute the topological order ignoring variables
   names(equations) <- nms
   deps <- collapse_dependencies(lapply(equations, function(eq) {
-    setdiff(eq$rhs$depends$variables, c(implicit, eq$lhs$name))
+    rhs_depends <- eq$rhs$depends$variables
+    lhs_depends <- NULL
+    if (length(eq$lhs$array) > 0) {
+      lhs_depends <- unlist(lapply(eq$lhs$array, function(x) {
+        as.character(x[["at"]])
+      }))
+    }
+    vars <- c(rhs_depends, lhs_depends)
+    setdiff(vars, c(implicit, eq$lhs$name))
   }))
   res <- topological_order(deps)
   if (!res$success) {
@@ -209,8 +217,17 @@ parse_system_depends <- function(equations, variables, call) {
 
   ## Now, we need to get the variables a second time, and only exclude
   ## automatic variables
+  
   deps <- lapply(equations, function(eq) {
-    setdiff(eq$rhs$depends$variables, automatic)
+    rhs_depends <- eq$rhs$depends$variables
+    lhs_depends <- NULL
+    if (length(eq$lhs$array) > 0) {
+      lhs_depends <- unlist(lapply(eq$lhs$array, function(x) {
+        as.character(x[["at"]])
+      }))
+    }
+    vars <- c(rhs_depends, lhs_depends)
+    setdiff(vars, automatic)
   })
   deps_recursive <- list()
   for (i in seq_along(deps)) {

--- a/R/parse_system.R
+++ b/R/parse_system.R
@@ -191,12 +191,11 @@ parse_array_range_depends <- function(x) {
         }
       }
       return(find_dependencies(x)$variables)
-    } 
+    }
   }
 }
 
 parse_array_depends <- function(arrays) {
-  
   lhs_depends <- NULL
   for (array in arrays) {
     if (array$type == "range") {
@@ -243,7 +242,7 @@ parse_system_depends <- function(equations, variables, call) {
 
   ## Now, we need to get the variables a second time, and only exclude
   ## automatic variables
-  
+
   deps <- lapply(equations, function(eq) {
     rhs_depends <- eq$rhs$depends$variables
     lhs_depends <- parse_array_depends(eq$lhs$array)

--- a/R/parse_system.R
+++ b/R/parse_system.R
@@ -184,9 +184,8 @@ parse_array_range_depends <- function(x) {
   } else {
     if (is.symbol(x)) {
       return(as.character(x))
-    } else if (is.expression(x)) {
-      browser()
-      return(find_dependencies(x))
+    } else if (is.call(x)) {
+      return(find_dependencies(x)$variables)
     } else if (as.character(x[[1]]) %in% c("OdinDim", "length")) {
       if (!is.numeric(x[[2]])) {
         return(as.character(x[[2]]))

--- a/tests/testthat/test-generate.R
+++ b/tests/testthat/test-generate.R
@@ -1827,3 +1827,85 @@ test_that("can generate pi", {
       "  state[0] = M_PI;",
       "}"))
 })
+
+test_that("Array assignment with index on lhs and rhs (1)", {
+  ## See (mrc-5894)
+  dat <- odin_parse({
+    seed_age_band <- as.integer(4)
+    n <- parameter(type = "integer", constant = TRUE)
+    dim(x) <- n
+    initial(y) <- 0
+    update(y) <- sum(x)
+    x[] <- Poisson(1)
+    x[seed_age_band] <- x[i] + 1
+  })
+  dat <- generate_prepare(dat)
+  src <- generate_dust_system_update(dat)
+  src <- src[grepl("seed_age_band", src)]
+  expect_equal(src,
+    paste0("  internal.x[shared.seed_age_band - 1] = ",
+             "internal.x[shared.seed_age_band - 1] + 1;"))
+    
+})
+
+test_that("Array assignment with index on lhs and rhs (2)", {
+  ## See (mrc-5894)
+  dat <- odin_parse({
+    seed_age_band <- as.integer(4)
+    
+    n <- parameter(type = "integer", constant = TRUE)
+    dim(x) <- n
+    
+    initial(y) <- 0
+    update(y) <- sum(x)
+    
+    lambda <- parameter()
+    dim(lambda) <- n
+    
+    x[] <- Poisson(lambda[i])
+    x[seed_age_band] <- x[i] + 1 + seed_age_band * 0
+  })
+  dat <- generate_prepare(dat)
+  src <- generate_dust_system_update(dat)
+  src <- src[grepl("seed_age_band", src)]
+  expect_equal(src,
+               paste0("  internal.x[shared.seed_age_band - 1] = ",
+                      "internal.x[shared.seed_age_band - 1] + 1 ",
+                      "+ shared.seed_age_band * 0;"))
+})
+
+test_that("Array assigment lhs: integer index, rhs: i", {
+  ## See (mrc-5894)
+  dat <- odin_parse({
+    n <- parameter(type = "integer", constant = TRUE)
+    dim(x) <- n
+    
+    initial(y) <- 0
+    update(y) <- sum(x)
+    
+    x[] <- Poisson(1)
+    x[4] <- x[i] + 1
+  })
+  dat <- generate_prepare(dat)
+  src <- generate_dust_system_update(dat)
+  src <- src[grepl("internal.x\\[", src)]
+  expect_true("  internal.x[3] = internal.x[3] + 1;" %in% src)
+})
+
+test_that("Array assigment lhs: expression index, rhs: i", {
+  ## See (mrc-5894)
+  dat <- odin_parse({
+    seed_age_band <- as.integer(4)
+    n <- parameter(type = "integer", constant = TRUE)
+    dim(x) <- n
+    initial(y) <- 0
+    update(y) <- sum(x)
+    x[] <- Poisson(1)
+    x[seed_age_band + 1] <- x[i] + 1
+  })
+  dat <- generate_prepare(dat)
+  src <- generate_dust_system_update(dat)
+  expect_true(paste0("  internal.x[shared.seed_age_band + 1 - 1] = ",
+                       "internal.x[shared.seed_age_band + 1 - 1] + 1;") %in% src)
+})
+

--- a/tests/testthat/test-generate.R
+++ b/tests/testthat/test-generate.R
@@ -1909,3 +1909,18 @@ test_that("Array assigment lhs: expression index, rhs: i", {
                        "internal.x[shared.seed_age_band + 1 - 1] + 1;") %in% src)
 })
 
+test_that("Array assigment lhs: length index, rhs: i", {
+  ## See (mrc-5894)
+  dat <- odin_parse({
+    n <- parameter(type = "integer", constant = TRUE)
+    dim(x) <- n
+    initial(y) <- 0
+    update(y) <- sum(x)
+    x[] <- Poisson(1)
+    x[length(x)] <- x[i] + 1
+  })
+  dat <- generate_prepare(dat)
+  src <- generate_dust_system_update(dat)
+  expect_true(paste0("  internal.x[shared.dim.x.size - 1] = ",
+                       "internal.x[shared.dim.x.size - 1] + 1;") %in% src)
+})

--- a/tests/testthat/test-parse-system.R
+++ b/tests/testthat/test-parse-system.R
@@ -189,20 +189,20 @@ test_that("Error if equations unused", {
 
 test_that("Equation used if result is used in array assignment", {
   ## See (mrc-5894)
-  dat <- odin2::odin({
+  dat <- odin_parse({
     seed_age_band <- as.integer(4)
     n <- parameter(type = "integer", constant = TRUE)
     dim(x) <- n
     initial(y) <- 0
     update(y) <- sum(x)
     x[] <- Poisson(1)
-    x[seed_age_band] <- x[seed_age_band] + 1
+    x[seed_age_band] <- x[i] + 1
   })
 })
 
 test_that("Equation used if result is used in array assignment", {
   ## See (mrc-5894)
-  dat <- odin2::odin({
+  dat <- odin_parse({
     seed_age_band <- as.integer(4)
     
     n <- parameter(type = "integer", constant = TRUE)
@@ -218,10 +218,6 @@ test_that("Equation used if result is used in array assignment", {
     x[seed_age_band] <- x[i] + 1 + seed_age_band * 0
   })
 })
-
-
-
-
 
 test_that("detect dependencies correctly across multline arrays", {
   dat <- odin_parse({

--- a/tests/testthat/test-parse-system.R
+++ b/tests/testthat/test-parse-system.R
@@ -187,6 +187,41 @@ test_that("Error if equations unused", {
     "Unused equations: 'x' and 'b'")
 })
 
+test_that("Equation used if result is used in array assignment", {
+  ## See (mrc-5894)
+  dat <- odin2::odin({
+    seed_age_band <- as.integer(4)
+    n <- parameter(type = "integer", constant = TRUE)
+    dim(x) <- n
+    initial(y) <- 0
+    update(y) <- sum(x)
+    x[] <- Poisson(1)
+    x[seed_age_band] <- x[seed_age_band] + 1
+  })
+})
+
+test_that("Equation used if result is used in array assignment", {
+  ## See (mrc-5894)
+  dat <- odin2::odin({
+    seed_age_band <- as.integer(4)
+    
+    n <- parameter(type = "integer", constant = TRUE)
+    dim(x) <- n
+    
+    initial(y) <- 0
+    update(y) <- sum(x)
+    
+    lambda <- parameter()
+    dim(lambda) <- n
+    
+    x[] <- Poisson(lambda[i])
+    x[seed_age_band] <- x[i] + 1 + seed_age_band * 0
+  })
+})
+
+
+
+
 
 test_that("detect dependencies correctly across multline arrays", {
   dat <- odin_parse({

--- a/tests/testthat/test-parse-system.R
+++ b/tests/testthat/test-parse-system.R
@@ -187,52 +187,6 @@ test_that("Error if equations unused", {
     "Unused equations: 'x' and 'b'")
 })
 
-test_that("Equation used if result is used in array assignment", {
-  ## See (mrc-5894)
-  dat <- odin2::odin({
-    seed_age_band <- as.integer(4)
-    n <- parameter(type = "integer", constant = TRUE)
-    dim(x) <- n
-    initial(y) <- 0
-    update(y) <- sum(x)
-    x[] <- Poisson(1)
-    x[seed_age_band] <- x[i] + 1
-  })
-})
-
-test_that("Equation used if result is used in array assignment", {
-  ## See (mrc-5894)
-  dat <- odin2::odin({
-    seed_age_band <- as.integer(4)
-    
-    n <- parameter(type = "integer", constant = TRUE)
-    dim(x) <- n
-    
-    initial(y) <- 0
-    update(y) <- sum(x)
-    
-    lambda <- parameter()
-    dim(lambda) <- n
-    
-    x[] <- Poisson(lambda[i])
-    x[seed_age_band] <- x[i] + 1 + seed_age_band * 0
-  })
-})
-
-test_that("Array assigment with integer index is handled", {
-  ## See (mrc-5894)
-  dat <- odin2::odin({
-    n <- parameter(type = "integer", constant = TRUE)
-    dim(x) <- n
-    
-    initial(y) <- 0
-    update(y) <- sum(x)
-    
-    x[] <- Poisson(1)
-    x[4] <- x[i] + 1
-  })
-})
-
 test_that("detect dependencies correctly across multline arrays", {
   dat <- odin_parse({
     a[] <- 0

--- a/tests/testthat/test-parse-system.R
+++ b/tests/testthat/test-parse-system.R
@@ -189,7 +189,7 @@ test_that("Error if equations unused", {
 
 test_that("Equation used if result is used in array assignment", {
   ## See (mrc-5894)
-  dat <- odin_parse({
+  dat <- odin2::odin({
     seed_age_band <- as.integer(4)
     n <- parameter(type = "integer", constant = TRUE)
     dim(x) <- n
@@ -202,7 +202,7 @@ test_that("Equation used if result is used in array assignment", {
 
 test_that("Equation used if result is used in array assignment", {
   ## See (mrc-5894)
-  dat <- odin_parse({
+  dat <- odin2::odin({
     seed_age_band <- as.integer(4)
     
     n <- parameter(type = "integer", constant = TRUE)
@@ -216,6 +216,20 @@ test_that("Equation used if result is used in array assignment", {
     
     x[] <- Poisson(lambda[i])
     x[seed_age_band] <- x[i] + 1 + seed_age_band * 0
+  })
+})
+
+test_that("Array assigment with integer index is handled", {
+  ## See (mrc-5894)
+  dat <- odin2::odin({
+    n <- parameter(type = "integer", constant = TRUE)
+    dim(x) <- n
+    
+    initial(y) <- 0
+    update(y) <- sum(x)
+    
+    x[] <- Poisson(1)
+    x[4] <- x[i] + 1
   })
 })
 


### PR DESCRIPTION
OBSOLETE - see #85 instead



Two issues this deals with, both reported by Ed in mrc-5894

* Variables that were set and used only in LHS array index were not detected when deciding whether they were ever used.
* x[var] <- x[i] + 1 is valid syntax and should result in x[var - 1] <- x[var - 1] + 1 

another couple emerged in the same code - these would not compile before and now do:
* x[4] <- x[i] should result in x[3] <- x[3]
* x[length(x)] <- x[i] should result (roughly) in x[dim.x.size - 1] <- x[dim.x.size - 1]

