### PR TITLE
Fix array indexing bugs (2)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: odin2
 Title: Next generation odin
-Version: 0.1.10
+Version: 0.1.11
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Imperial College of Science, Technology and Medicine",

--- a/R/generate_dust.R
+++ b/R/generate_dust.R
@@ -675,7 +675,7 @@ generate_dust_assignment <- function(eq, name_state, dat, options = list()) {
                            idx$name, from, idx$name, to, idx$name),
                    res,
                    "}")
-        } else {
+        } else if (idx$name %in% find_dependencies(eq$rhs$expr)$variables) {
           at <- generate_dust_sexp(idx$at, dat$sexp_data, options)
           res <- c("{",
                    sprintf("const size_t %s = %s;", idx$name, at),

--- a/R/generate_dust.R
+++ b/R/generate_dust.R
@@ -675,12 +675,19 @@ generate_dust_assignment <- function(eq, name_state, dat, options = list()) {
                            idx$name, from, idx$name, to, idx$name),
                    res,
                    "}")
+        } else {
+          at <- generate_dust_sexp(idx$at, dat$sexp_data, options)
+          res <- c("{",
+                   sprintf("const size_t %s = %s;", idx$name, at),
+                   res,
+                   "}")
         }
       }
       if (length(res) > 1) {
-        n <- (length(res) - 1) / 2
-        indent <- strrep("  ", c(seq_len(n + 1), rev(seq_len(n))) - 1)
-        res <- paste0(indent, res)
+        i_start <- c(FALSE, grepl("^(for|\\{)", res[-length(res)])) 
+        i_end <- grepl("^}", res) 
+        indent <- strrep("  ", cumsum(i_start - i_end)) 
+        res <- paste0(indent, res) 
       }
     }
   }

--- a/R/generate_dust.R
+++ b/R/generate_dust.R
@@ -660,7 +660,6 @@ generate_dust_assignment <- function(eq, name_state, dat, options = list()) {
     res <- sprintf("%s;",
                    generate_dust_sexp(eq$rhs$expr, dat$sexp_data, options))
   } else {
-    is_array <- !is.null(eq$lhs$array)
     lhs <- generate_dust_lhs(eq$lhs, dat, name_state, options)
     rhs <- generate_dust_sexp(eq$rhs$expr, dat$sexp_data, options)
 
@@ -684,10 +683,10 @@ generate_dust_assignment <- function(eq, name_state, dat, options = list()) {
         }
       }
       if (length(res) > 1) {
-        i_start <- c(FALSE, grepl("^(for|\\{)", res[-length(res)])) 
-        i_end <- grepl("^}", res) 
-        indent <- strrep("  ", cumsum(i_start - i_end)) 
-        res <- paste0(indent, res) 
+        i_start <- c(FALSE, grepl("^(for|\\{)", res[-length(res)]))
+        i_end <- grepl("^}", res)
+        indent <- strrep("  ", cumsum(i_start - i_end))
+        res <- paste0(indent, res)
       }
     }
   }

--- a/R/parse_expr.R
+++ b/R/parse_expr.R
@@ -109,6 +109,7 @@ parse_expr_assignment <- function(expr, src, call) {
         "E1038", src, call)
     }
   }
+
   list(special = special,
        lhs = lhs,
        rhs = rhs,
@@ -515,7 +516,7 @@ parse_expr_compare <- function(expr, src, call) {
   if (lhs == "pi") {
     odin_parse_error(
       "Do not use `pi` on the left-hand-side of an expression",
-      "E1061", src, call)  
+      "E1061", src, call)
   }
   rhs$args <- c(lhs, rhs$args)
   rhs$depends$variables <- union(rhs$depends$variables, as.character(lhs))

--- a/R/parse_expr.R
+++ b/R/parse_expr.R
@@ -77,7 +77,7 @@ parse_expr_assignment <- function(expr, src, call) {
       }
     }
   }
-
+  
   index_used <- intersect(INDEX, rhs$depends$variables)
   if (length(index_used) > 0) {
     n <- length(lhs$array)
@@ -109,7 +109,6 @@ parse_expr_assignment <- function(expr, src, call) {
         "E1038", src, call)
     }
   }
-
   list(special = special,
        lhs = lhs,
        rhs = rhs,
@@ -165,15 +164,20 @@ parse_expr_assignment_lhs <- function(lhs, src, call) {
                  seq_len(length(lhs) - 2),
                  lhs[-(1:2)],
                  MoreArgs = list(name = name, src = src, call = call))
+    depends <- join_dependencies(
+      lapply(array, function(x)
+        join_dependencies(lapply(x[c("at", "from", "to")], find_dependencies))))
   } else {
     name <- parse_expr_check_lhs_name(lhs, special, is_array, src, call)
     array <- NULL
+    depends <- NULL
   }
 
   lhs <- list(
     name = name,
     special = special,
-    array = array)
+    array = array,
+    depends = depends)
 
   if (!is.null(args)) {
     lhs$args <- args

--- a/R/parse_expr.R
+++ b/R/parse_expr.R
@@ -77,7 +77,7 @@ parse_expr_assignment <- function(expr, src, call) {
       }
     }
   }
-  
+
   index_used <- intersect(INDEX, rhs$depends$variables)
   if (length(index_used) > 0) {
     n <- length(lhs$array)

--- a/R/parse_system.R
+++ b/R/parse_system.R
@@ -187,7 +187,8 @@ parse_system_depends <- function(equations, variables, call) {
   ## First, compute the topological order ignoring variables
   names(equations) <- nms
   deps <- collapse_dependencies(lapply(equations, function(eq) {
-    setdiff(eq$rhs$depends$variables, c(implicit, eq$lhs$name))
+    setdiff(unique(c(eq$lhs$depends$variables, eq$rhs$depends$variables)), 
+            c(implicit, eq$lhs$name))
   }))
   res <- topological_order(deps)
   if (!res$success) {
@@ -210,7 +211,8 @@ parse_system_depends <- function(equations, variables, call) {
   ## Now, we need to get the variables a second time, and only exclude
   ## automatic variables
   deps <- lapply(equations, function(eq) {
-    setdiff(eq$rhs$depends$variables, automatic)
+    setdiff(unique(c(eq$lhs$depends$variables, eq$rhs$depends$variables)), 
+            automatic)
   })
   deps_recursive <- list()
   for (i in seq_along(deps)) {

--- a/tests/testthat/test-generate.R
+++ b/tests/testthat/test-generate.R
@@ -1840,8 +1840,6 @@ test_that("Array assignment with index on lhs and rhs (1)", {
     x[seed_age_band] <- x[i] + 1
   })
   dat <- generate_prepare(dat)
-  src <- generate_dust_system_update(dat)
-  src <- src[grepl("seed_age_band", src)]
   expect_equal(
     generate_dust_system_update(dat),
     c(method_args$update,
@@ -1861,16 +1859,48 @@ test_that("Array assignment with index on lhs and rhs (1)", {
   ## See (mrc-5894)
   dat <- odin_parse({
     seed_age_band <- as.integer(4)
+
     n <- parameter(type = "integer", constant = TRUE)
     dim(x) <- n
+
     initial(y) <- 0
     update(y) <- sum(x)
-    x[] <- Poisson(1)
-    x[seed_age_band] <- x[i] + 1
+
+    lambda <- parameter()
+    dim(lambda) <- n
+
+    x[] <- Poisson(lambda[i])
+    x[seed_age_band] <- x[i] + 1 + seed_age_band * 0
   })
   dat <- generate_prepare(dat)
-  src <- generate_dust_system_update(dat)
-  src <- src[grepl("seed_age_band", src)]
+  expect_equal(
+    generate_dust_system_update(dat),
+    c(method_args$update,
+      "  for (size_t i = 1; i <= shared.dim.x.size; ++i) {",
+      "    internal.x[i - 1] = monty::random::poisson<real_type>(rng_state, shared.lambda[i - 1]);",
+      "  }",
+      "  {",
+      "    const size_t i = shared.seed_age_band;",
+      "    internal.x[shared.seed_age_band - 1] = internal.x[i - 1] + 1 + shared.seed_age_band * 0;",
+      "  }",
+      "  state_next[0] = dust2::array::sum<real_type>(internal.x.data(), shared.dim.x);",
+      "}")
+  )
+})
+
+test_that("Array assigment lhs: integer index, rhs: i", {
+  ## See (mrc-5894)
+  dat <- odin_parse({
+    n <- parameter(type = "integer", constant = TRUE)
+    dim(x) <- n
+
+    initial(y) <- 0
+    update(y) <- sum(x)
+
+    x[] <- Poisson(1)
+    x[4] <- x[i] + 1
+  })
+  dat <- generate_prepare(dat)
   expect_equal(
     generate_dust_system_update(dat),
     c(method_args$update,
@@ -1878,8 +1908,61 @@ test_that("Array assignment with index on lhs and rhs (1)", {
       "    internal.x[i - 1] = monty::random::poisson<real_type>(rng_state, 1);",
       "  }",
       "  {",
-      "    const size_t i = shared.seed_age_band;",
-      "    internal.x[shared.seed_age_band - 1] = internal.x[i - 1] + 1;",
+      "    const size_t i = 4;",
+      "    internal.x[3] = internal.x[i - 1] + 1;",
+      "  }",
+      "  state_next[0] = dust2::array::sum<real_type>(internal.x.data(), shared.dim.x);",
+      "}")
+  )
+})
+
+test_that("Array assigment lhs: expression index, rhs: i", {
+  ## See (mrc-5894)
+  dat <- odin_parse({
+    seed_age_band <- as.integer(4)
+    n <- parameter(type = "integer", constant = TRUE)
+    dim(x) <- n
+    initial(y) <- 0
+    update(y) <- sum(x)
+    x[] <- Poisson(1)
+    x[seed_age_band + 1] <- x[i] + 1
+  })
+  dat <- generate_prepare(dat)
+  expect_equal(
+    generate_dust_system_update(dat),
+    c(method_args$update,
+      "  for (size_t i = 1; i <= shared.dim.x.size; ++i) {",
+      "    internal.x[i - 1] = monty::random::poisson<real_type>(rng_state, 1);",
+      "  }",
+      "  {",
+      "    const size_t i = shared.seed_age_band + 1;",
+      "    internal.x[shared.seed_age_band + 1 - 1] = internal.x[i - 1] + 1;",
+      "  }",
+      "  state_next[0] = dust2::array::sum<real_type>(internal.x.data(), shared.dim.x);",
+      "}")
+  )
+})
+
+test_that("Array assigment lhs: length index, rhs: i", {
+  ## See (mrc-5894)
+  dat <- odin_parse({
+    n <- parameter(type = "integer", constant = TRUE)
+    dim(x) <- n
+    initial(y) <- 0
+    update(y) <- sum(x)
+    x[] <- Poisson(1)
+    x[length(x)] <- x[i] + 1
+  })
+  dat <- generate_prepare(dat)
+  expect_equal(
+    generate_dust_system_update(dat),
+    c(method_args$update,
+      "  for (size_t i = 1; i <= shared.dim.x.size; ++i) {",
+      "    internal.x[i - 1] = monty::random::poisson<real_type>(rng_state, 1);",
+      "  }",
+      "  {",
+      "    const size_t i = shared.dim.x.size;",
+      "    internal.x[shared.dim.x.size - 1] = internal.x[i - 1] + 1;",
       "  }",
       "  state_next[0] = dust2::array::sum<real_type>(internal.x.data(), shared.dim.x);",
       "}")

--- a/tests/testthat/test-generate.R
+++ b/tests/testthat/test-generate.R
@@ -1827,3 +1827,61 @@ test_that("can generate pi", {
       "  state[0] = M_PI;",
       "}"))
 })
+
+test_that("Array assignment with index on lhs and rhs (1)", {
+  ## See (mrc-5894)
+  dat <- odin_parse({
+    seed_age_band <- as.integer(4)
+    n <- parameter(type = "integer", constant = TRUE)
+    dim(x) <- n
+    initial(y) <- 0
+    update(y) <- sum(x)
+    x[] <- Poisson(1)
+    x[seed_age_band] <- x[i] + 1
+  })
+  dat <- generate_prepare(dat)
+  src <- generate_dust_system_update(dat)
+  src <- src[grepl("seed_age_band", src)]
+  expect_equal(
+    generate_dust_system_update(dat),
+    c(method_args$update,
+      "  for (size_t i = 1; i <= shared.dim.x.size; ++i) {",
+      "    internal.x[i - 1] = monty::random::poisson<real_type>(rng_state, 1);",
+      "  }",
+      "  {",
+      "    const size_t i = shared.seed_age_band;",
+      "    internal.x[shared.seed_age_band - 1] = internal.x[i - 1] + 1;",
+      "  }",
+      "  state_next[0] = dust2::array::sum<real_type>(internal.x.data(), shared.dim.x);",
+      "}")
+  )
+})
+
+test_that("Array assignment with index on lhs and rhs (1)", {
+  ## See (mrc-5894)
+  dat <- odin_parse({
+    seed_age_band <- as.integer(4)
+    n <- parameter(type = "integer", constant = TRUE)
+    dim(x) <- n
+    initial(y) <- 0
+    update(y) <- sum(x)
+    x[] <- Poisson(1)
+    x[seed_age_band] <- x[i] + 1
+  })
+  dat <- generate_prepare(dat)
+  src <- generate_dust_system_update(dat)
+  src <- src[grepl("seed_age_band", src)]
+  expect_equal(
+    generate_dust_system_update(dat),
+    c(method_args$update,
+      "  for (size_t i = 1; i <= shared.dim.x.size; ++i) {",
+      "    internal.x[i - 1] = monty::random::poisson<real_type>(rng_state, 1);",
+      "  }",
+      "  {",
+      "    const size_t i = shared.seed_age_band;",
+      "    internal.x[shared.seed_age_band - 1] = internal.x[i - 1] + 1;",
+      "  }",
+      "  state_next[0] = dust2::array::sum<real_type>(internal.x.data(), shared.dim.x);",
+      "}")
+  )
+})

--- a/tests/testthat/test-parse-expr-array.R
+++ b/tests/testthat/test-parse-expr-array.R
@@ -55,6 +55,35 @@ test_that("can parse array expression", {
 })
 
 
+test_that("can parse array expression", {
+  res <- parse_expr(quote(a[] <- 1), NULL, NULL)
+  expect_null(res$special)
+  expect_equal(res$lhs$name, "a")
+  expect_equal(res$lhs$array,
+               list(list(name = "i",
+                         type = "range",
+                         from = 1,
+                         to = quote(OdinDim("a", 1L)))))
+  expect_equal(res$rhs$type, "expression")
+  expect_equal(res$rhs$expr, 1)
+})
+
+
+test_that("can parse array dependencies", {
+  res <- parse_expr(quote(a[banana] <- b), NULL, NULL)
+  expect_null(res$special)
+  expect_equal(res$lhs$name, "a")
+  expect_equal(res$lhs$array,
+               list(list(name = "i",
+                         type = "single",
+                         at = as.symbol("banana"))))
+  expect_equal(res$lhs$depends$variables, "banana")
+  expect_equal(res$rhs$type, "expression")
+  expect_equal(res$rhs$expr, as.symbol("b"))
+  expect_equal(res$rhs$depends$variables, "b")
+})
+
+
 test_that("can't use array access with higher rank than the lhs implies", {
   expect_error(
     parse_expr(quote(a[] <- x[j]), NULL, NULL),

--- a/tests/testthat/test-parse-expr-array.R
+++ b/tests/testthat/test-parse-expr-array.R
@@ -55,20 +55,6 @@ test_that("can parse array expression", {
 })
 
 
-test_that("can parse array expression", {
-  res <- parse_expr(quote(a[] <- 1), NULL, NULL)
-  expect_null(res$special)
-  expect_equal(res$lhs$name, "a")
-  expect_equal(res$lhs$array,
-               list(list(name = "i",
-                         type = "range",
-                         from = 1,
-                         to = quote(OdinDim("a", 1L)))))
-  expect_equal(res$rhs$type, "expression")
-  expect_equal(res$rhs$expr, 1)
-})
-
-
 test_that("can parse array dependencies", {
   res <- parse_expr(quote(a[banana] <- b), NULL, NULL)
   expect_null(res$special)

--- a/tests/testthat/test-parse-expr-interpolate.R
+++ b/tests/testthat/test-parse-expr-interpolate.R
@@ -38,7 +38,8 @@ test_that("parse interpolation call", {
   res <- parse_expr(quote(x <- interpolate(a, b, "constant")), NULL, NULL)
   expect_null(res$special)
   expect_equal(res$lhs,
-               list(name = "interpolate_x", array = NULL, name_data = "x"))
+               list(name = "interpolate_x", array = NULL, depends = NULL, 
+                    name_data = "x"))
   expect_equal(res$rhs$type, "interpolate")
   expect_equal(
     res$rhs$expr,

--- a/tests/testthat/test-parse-expr.R
+++ b/tests/testthat/test-parse-expr.R
@@ -242,7 +242,7 @@ test_that("Reject unclassifiable expressions", {
 test_that("can parse expressions that involve stochastics", {
   res <- parse_expr(quote(a <- Normal(0, 1)), NULL, NULL)
   expect_null(res$special)
-  expect_equal(res$lhs, list(name = "a", array = NULL))
+  expect_equal(res$lhs, list(name = "a", array = NULL, depends = NULL))
   expect_identical(
     res$rhs$expr,
     quote(OdinStochasticCall(sample = "normal", mean = 0)(0, 1)))


### PR DESCRIPTION
Take two making this PR better - 

Two issues this deals with, both reported by Ed in mrc-5894

* Variables that were set and used only in LHS array index were not detected when deciding whether they were ever used.
* x[var] <- x[i] + 1 is valid syntax and should result in x[var - 1] <- x[var - 1] + 1 

another couple emerged in the same code - these would not compile before and now do:
* x[4] <- x[i] should result in x[3] <- x[3]
* x[length(x)] <- x[i] should result (roughly) in x[dim.x.size - 1] <- x[dim.x.size - 1]