### PR TITLE
Make parameters constant automatically

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 PACKAGE := $(shell grep '^Package:' DESCRIPTION | sed -E 's/^Package:[[:space:]]+//')
-RSCRIPT = Rscript --no-init-file
+RSCRIPT = Rscript
 
 all:
 	${RSCRIPT} -e 'pkgbuild::compile_dll()'

--- a/tests/testthat/test-generate.R
+++ b/tests/testthat/test-generate.R
@@ -522,6 +522,12 @@ test_that("generate adjoint", {
       "  adjoint_next[0] = adj_x;",
       "  adjoint_next[1] = adj_a;",
       "}"))
+
+  expect_equal(
+    generate_dust_system_update_shared(dat),
+    c(method_args$update_shared,
+      '  shared.a = dust2::r::read_real(parameters, "a", shared.a);',
+      "}"))
 })
 
 

--- a/tests/testthat/test-parse-expr.R
+++ b/tests/testthat/test-parse-expr.R
@@ -141,9 +141,20 @@ test_that("can't use both constant and differentiate", {
 })
 
 
+test_that("differentiable parameters are not constant", {
+  res <- parse_expr(quote(a <- parameter(differentiate = TRUE)),
+                    NULL, NULL)
+  expect_mapequal(res$rhs$args,
+                  list(default = NULL,
+                       constant = FALSE,
+                       differentiate = TRUE,
+                       type = "real_type",
+                       rank = NULL))
+})
+
 test_that("can change parameter type", {
   res <- parse_expr(quote(a <- parameter()), NULL, NULL)
-  expect_equal(res$rhs$args$type, "real_type")
+  expect_equal(res$rhs$args$type, NA_character_)
   res <- parse_expr(quote(a <- parameter(type = "real")), NULL, NULL)
   expect_equal(res$rhs$args$type, "real_type")
   res <- parse_expr(quote(a <- parameter(type = "integer")), NULL, NULL)

--- a/tests/testthat/test-parse-system.R
+++ b/tests/testthat/test-parse-system.R
@@ -241,7 +241,7 @@ test_that("System can use pi", {
 })
 
 
-test_that("can throw sensible error in when a dimension is unknown", {
+test_that("can throw sensible error when a dimension is unknown", {
   err <- expect_error(
     odin_parse({
       dim(x) <- c(a + 1, b)

--- a/tests/testthat/test-parse-system.R
+++ b/tests/testthat/test-parse-system.R
@@ -123,6 +123,21 @@ test_that("parameters default to constant in face of differentiability", {
                           constant = c(TRUE, TRUE, FALSE)))
 })
 
+test_that("differentiable parameters default to not being constant", {
+  dat <- odin_parse({
+    update(x) <- x + a
+    initial(x) <- 1
+    a <- parameter(differentiate = TRUE)
+    p <- exp(x)
+    d <- data()
+    d ~ Poisson(p)
+  })
+  expect_equal(dat$parameters,
+               data_frame(name = "a",
+                          type = "real_type",
+                          differentiate = TRUE,
+                          constant = FALSE))
+})
 
 test_that("fail informatively if recursive depenency in equations", {
   err <- expect_error(
@@ -229,7 +244,7 @@ test_that("System can use pi", {
 test_that("can throw sensible error in when a dimension is unknown", {
   err <- expect_error(
     odin_parse({
-      dim(x) <- c(a, b)
+      dim(x) <- c(a + 1, b)
       x[, ] <- 0
       a <- parameter()
       initial(y) <- 0

--- a/tests/testthat/test-parse.R
+++ b/tests/testthat/test-parse.R
@@ -534,7 +534,7 @@ test_that("cannot use browser in nonexistant phase", {
 })
 
 
-test_that("can automatically find make parameters constant", {
+test_that("can automatically make parameters constant", {
   dat <- odin_parse({
     n <- parameter()
     dim(x) <- n


### PR DESCRIPTION
This PR sets `constant = TRUE, type = "integer"` on parameters that are used trivially in dimensions (as in directly, as a symbol within a `dim` call).  This is the only allowed combination of arguments, so we should just set this up rather than expecting the user to write it out everywhere

~Merge after #87, contains that commit~