### PR TITLE
Allow integers to be saved as such

### DIFF
--- a/R/parse_expr.R
+++ b/R/parse_expr.R
@@ -60,6 +60,12 @@ parse_expr_assignment <- function(expr, src, call) {
     }
     lhs$name_data <- lhs$name
     lhs$name <- paste0("interpolate_", lhs$name)
+  } else {
+    if (rlang::is_call(rhs$expr, "as.integer")) {
+      lhs$storage_type <- "int"
+    } else if (rlang::is_call(rhs$expr, "as.logical")) {
+      lhs$storage_type <- "bool"
+    }
   }
 
   if (identical(special, "initial")) {
@@ -446,7 +452,8 @@ parse_expr_assignment_rhs_parameter <- function(rhs, src, call) {
 
   ## NOTE: this is assuming C++ types here, which is not great, but we
   ## can iron that out when thinking about the js version. It might be
-  ## nicer to do the type translation at generation?
+  ## nicer to do the type translation at generation? See also above
+  ## where we use int/bool too.
   if (!is.na(args$type)) {
     args$type <- switch(args$type,
                         "real" = "real_type",

--- a/R/parse_system.R
+++ b/R/parse_system.R
@@ -438,6 +438,14 @@ parse_storage <- function(equations, phases, variables, arrays, parameters,
   type <- set_names(rep("real_type", length(location)), names(location))
   type[parameters$name] <- parameters$type
 
+  storage_type <- vcapply(equations,
+                          function(eq) eq$lhs$storage_type %||% NA_character_)
+  i <- !is.na(storage_type)
+  if (any(i)) {
+    stopifnot(!anyDuplicated(names(storage_type[i]))) # array corner case
+    type[names(storage_type[i])] <- storage_type[i]
+  }
+
   is_interpolate <- vlapply(equations[names(location)],
                             function(x) identical(x$rhs$type, "interpolate"))
   type[names(type) %in% names(which(is_interpolate))] <- "interpolator"

--- a/tests/testthat/test-parse-expr.R
+++ b/tests/testthat/test-parse-expr.R
@@ -603,3 +603,13 @@ test_that("Can't parse with pi on lhs", {
 })
 
 
+test_that("top-level calls to as.integer create integer variables", {
+  res <- parse_expr(quote(a <- as.integer(b)), NULL, NULL)
+  expect_equal(res$lhs$storage_type, "int")
+})
+
+
+test_that("top-level calls to as.logical create logical variables", {
+  res <- parse_expr(quote(a <- as.logical(b)), NULL, NULL)
+  expect_equal(res$lhs$storage_type, "bool")
+})

--- a/tests/testthat/test-parse-system.R
+++ b/tests/testthat/test-parse-system.R
@@ -263,3 +263,15 @@ test_that("can throw sensible error when a dimension is unknown", {
     err$body[[2]],
     "Try adding `constant = TRUE` into the 'parameter()' call for 'a'")
 })
+
+
+test_that("correct storage type when coersion used", {
+  dat <- odin_parse({
+    a <- as.integer(5)
+    b <- as.logical(TRUE)
+    update(x) <- if (b) a else 0
+    initial(x) <- 0
+  })
+  expect_mapequal(dat$storage$type,
+                  c(x = "real_type", a = "int", b = "bool"))
+})


### PR DESCRIPTION
This PR allows writing

```
a <- as.integer(<expr>)
```

to set up `a` as an integer, allowing us to easily use it as an array subscript