### PR TITLE
Generate parameter attributes

### DIFF
--- a/R/generate_dust.R
+++ b/R/generate_dust.R
@@ -69,10 +69,24 @@ generate_dust_system_attributes <- function(dat) {
   } else {
     has_adjoint <- "// [[dust2::has_adjoint()]]"
   }
+  pars <- dat$parameters
+  if (!is.null(pars)) {
+    keep <- c("type", "rank", "required", "constant")
+    str <- matrix(
+      unlist0(lapply(pars[keep], vcapply, deparse, control = NULL)),
+      ncol = length(keep))
+    args <- apply(str, 1, function(el) {
+      paste(sprintf("%s = %s", keep, el), collapse = ", ")
+    })
+    parameters <- sprintf("// [[dust2::parameter(%s, %s)]]", pars$name, args)
+  } else {
+    parameters <- NULL
+  }
   c(sprintf("// [[dust2::class(%s)]]", dat$class),
     sprintf("// [[dust2::time_type(%s)]]", dat$time),
     has_compare,
-    has_adjoint)
+    has_adjoint,
+    parameters)
 }
 
 

--- a/tests/testthat/test-generate.R
+++ b/tests/testthat/test-generate.R
@@ -11,6 +11,38 @@ test_that("generate basic attributes for trivial system", {
 })
 
 
+test_that("generate basic attributes for system with parameters", {
+  dat <- odin_parse({
+    update(x) <- 1
+    initial(x) <- a + b
+    a <- parameter(1)
+    b <- parameter()
+  })
+  dat <- generate_prepare(dat)
+  expect_equal(
+    generate_dust_system_attributes(dat),
+    c("// [[dust2::class(odin)]]",
+      "// [[dust2::time_type(discrete)]]",
+      '// [[dust2::parameter(a, type = "real_type", rank = 0, required = FALSE, constant = FALSE)]]',
+      '// [[dust2::parameter(b, type = "real_type", rank = 0, required = TRUE, constant = FALSE)]]'))
+})
+
+
+test_that("generate basic attributes for system with a single parameter", {
+  dat <- odin_parse({
+    update(x) <- 1
+    initial(x) <- a
+    a <- parameter(1)
+  })
+  dat <- generate_prepare(dat)
+  expect_equal(
+    generate_dust_system_attributes(dat),
+    c("// [[dust2::class(odin)]]",
+      "// [[dust2::time_type(discrete)]]",
+      '// [[dust2::parameter(a, type = "real_type", rank = 0, required = FALSE, constant = FALSE)]]'))
+})
+
+
 test_that("generate trivial types for trivial system", {
   dat <- odin_parse({
     update(x) <- 1

--- a/tests/testthat/test-zzz-integration.R
+++ b/tests/testthat/test-zzz-integration.R
@@ -35,6 +35,13 @@ test_that("can compile a simple ode model", {
   })
 
   expect_equal(s, cmp[1:3])
+
+  expect_equal(coef(res),
+               data_frame(name = c("N", "beta", "gamma", "I0"),
+                          type = "real_type",
+                          constant = c(TRUE, FALSE, FALSE, FALSE),
+                          required = FALSE,
+                          rank = 0))
 })
 
 


### PR DESCRIPTION
Currently we do not do this, so dust cheerfully prints "there's no parameters!" which is not ideal.  This PR generates the appropriate attributes for dust, which sorts the rest out for us

~Merge after #92, contains those commits~