### PR TITLE
Don't duplicate variables with boundary conditions in initial

### DIFF
--- a/R/parse_system.R
+++ b/R/parse_system.R
@@ -13,7 +13,7 @@ parse_system_overall <- function(exprs, call) {
   is_equation <- special %in% c("", "parameter", "dim") & !is_compare
 
   ## We take initial as the set of variables:
-  variables <- vcapply(exprs[is_initial], function(x) x$lhs$name)
+  variables <- unique(vcapply(exprs[is_initial], function(x) x$lhs$name))
   if (length(variables) == 0) {
     odin_parse_error("Did not find any call to 'initial()'",
                      "E2001", NULL, call)

--- a/tests/testthat/test-parse.R
+++ b/tests/testthat/test-parse.R
@@ -689,3 +689,15 @@ test_that("Spot rank inconsistency when dim uses parameter(rank)", {
     }),
     "Array rank in expression differs from the rank")
 })
+
+
+test_that("don't duplicate offsets when boundary condition used in initial", {
+  dat <- odin_parse({
+    initial(x[]) <- 0
+    initial(x[1]) <- 1
+    update(x[]) <- x + 1
+    dim(x) <- 4
+  })
+  expect_equal(dat$variables, "x")
+  expect_equal(nrow(dat$storage$packing$state), 1)
+})


### PR DESCRIPTION
As seen in sircovid. Where we had a boundary condition within `initial()`:

```r
    initial(x[]) <- 0
    initial(x[1]) <- 1
```

we would then count `x` twice as a variable, leading to all sorts of weird and eventually a compilation error where two offsets were generated.