### PR TITLE
Prevent signedness warning between int and size_t comparison

### DIFF
--- a/R/generate_dust.R
+++ b/R/generate_dust.R
@@ -678,6 +678,10 @@ generate_dust_assignment <- function(eq, name_state, dat, options = list()) {
         if (idx$type == "range") {
           from <- generate_dust_sexp(idx$from, dat$sexp_data, options)
           to <- generate_dust_sexp(idx$to, dat$sexp_data, options)
+          size_fns <- c("length", "dim", "OdinDim", "OdinLength")
+          if (!rlang::is_call(idx$to, size_fns) && !is.numeric(idx$to)) {
+            to <- sprintf("static_cast<size_t>(%s)", to)
+          }
           res <- c(sprintf("for (size_t %s = %s; %s <= %s; ++%s) {",
                            idx$name, from, idx$name, to, idx$name),
                    res,

--- a/tests/testthat/test-generate.R
+++ b/tests/testthat/test-generate.R
@@ -2006,3 +2006,23 @@ test_that("Array assigment lhs: length index, rhs: i", {
       "}")
   )
 })
+
+
+test_that("cast integers to sizes", {
+  dat <- odin_parse({
+    n <- parameter(5, type = "integer")
+    dim(x) <- n
+    x[1:n] <- time
+    initial(y) <- 0
+    update(y) <- x[1]
+  })
+  dat <- generate_prepare(dat)
+  expect_equal(
+    generate_dust_system_update(dat),
+    c(method_args$update,
+      "  for (size_t i = 1; i <= static_cast<size_t>(shared.n); ++i) {",
+      "    internal.x[i - 1] = time;",
+      "  }",
+      "  state_next[0] = internal.x[0];",
+      "}"))
+})


### PR DESCRIPTION
Seen in sircovid:

```
   dust.cpp: In static member function ‘static void odin::update(odin::real_type, odin::real_type, const real_type*, const odin::shared_state&, odin::internal_state&, odin::rng_state_type&, odin::real_type*)’:
   dust.cpp:3715:28: warning: comparison of integer expressions of different signedness: ‘size_t’ {aka ‘long unsigned int’} and ‘const int’ [-Wsign-compare]
    3715 |       for (size_t j = 1; j <= shared.n_groups; ++j) {
         |                          ~~^~~~~~~~~~~~~~~~~~
```

The test case included here produces the same warning on main, fixed with the cast added here