### PR TITLE
Allow aliases in arrays

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: odin2
 Title: Next generation odin
-Version: 0.2.7
+Version: 0.2.8
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Wes", "Hinsley", role = "aut"),

--- a/R/generate_dust.R
+++ b/R/generate_dust.R
@@ -50,6 +50,7 @@ generate_prepare <- function(dat) {
   dat$sexp_data <- generate_dust_dat(dat$storage$location,
                                      dat$storage$packing,
                                      dat$storage$type,
+                                     dat$storage$arrays,
                                      rank, alias)
   dat
 }

--- a/R/generate_dust.R
+++ b/R/generate_dust.R
@@ -50,8 +50,7 @@ generate_prepare <- function(dat) {
   dat$sexp_data <- generate_dust_dat(dat$storage$location,
                                      dat$storage$packing,
                                      dat$storage$type,
-                                     dat$storage$arrays,
-                                     rank, alias)
+                                     dat$storage$arrays)
   dat
 }
 

--- a/R/generate_dust_sexp.R
+++ b/R/generate_dust_sexp.R
@@ -190,9 +190,8 @@ generate_dust_sexp <- function(expr, dat, options = list()) {
 ## now all we need is information on where things are to be found (the
 ## location) but we'll need to cope with variable packing, array
 ## lengths and types soon.
-generate_dust_dat <- function(location, packing, type, arrays, rank, alias) {
-  list(location = location, packing = packing, type = type, arrays = arrays,
-       rank = rank, alias = alias)
+generate_dust_dat <- function(location, packing, type, arrays) {
+  list(location = location, packing = packing, type = type, arrays = arrays)
 }
 
 

--- a/R/parse_system.R
+++ b/R/parse_system.R
@@ -684,6 +684,15 @@ parse_packing <- function(names, arrays, no_reorder, type) {
     packing <- arrays
   }
 
+  ## Resolve aliases to give us a full set of sizes:
+  is_alias <- packing$name != packing$alias
+  if (any(is_alias)) {
+    i <- match(packing$alias[is_alias], packing$name)
+    packing$size[is_alias] <- packing$size[i]
+    packing$dims[is_alias] <- packing$dims[i]
+  }
+  packing$alias <- NULL
+
   packing <- packing[match(names, packing$name), ]
   pack_first <- vlapply(packing$size, is.numeric) &
     !(packing$name %in% no_reorder)

--- a/tests/testthat/test-generate-dust-sexp.R
+++ b/tests/testthat/test-generate-dust-sexp.R
@@ -1,5 +1,5 @@
 test_that("can generate basic literal values", {
-  dat <- generate_dust_dat(NULL, NULL, NULL, NULL, NULL)
+  dat <- generate_dust_dat(NULL, NULL, NULL, NULL)
   options <- list()
 
   expect_equal(generate_dust_sexp(TRUE, dat, options), "true")
@@ -15,7 +15,7 @@ test_that("can generate basic literal values", {
 
 
 test_that("can generate min/max expressions", {
-  dat <- generate_dust_dat(c(a = "shared", b = "stack"), NULL, NULL, NULL, NULL)
+  dat <- generate_dust_dat(c(a = "shared", b = "stack"), NULL, NULL, NULL)
   options <- list()
   expect_equal(generate_dust_sexp(quote(min(a, b)), dat, options),
                "monty::math::min(shared.a, b)")
@@ -27,7 +27,7 @@ test_that("can generate min/max expressions", {
 
 
 test_that("can cast types", {
-  dat <- generate_dust_dat(c(a = "shared"), NULL, NULL, NULL, NULL)
+  dat <- generate_dust_dat(c(a = "shared"), NULL, NULL, NULL)
   options <- list()
   expect_equal(generate_dust_sexp(quote(as.integer(1)), dat, options),
                "static_cast<int>(1)")
@@ -41,7 +41,7 @@ test_that("can cast types", {
 
 
 test_that("time and dt are always available", {
-  dat <- generate_dust_dat(NULL, NULL, NULL, NULL, NULL)
+  dat <- generate_dust_dat(NULL, NULL, NULL, NULL)
   options <- list()
   expect_equal(generate_dust_sexp("time", dat, options), "time")
   expect_equal(generate_dust_sexp("dt", dat, options), "dt")
@@ -57,8 +57,7 @@ test_that("can generate simple expressions involving arithmetic", {
       e = "data"),
     packing = list(state = parse_packing("a", NULL, NULL, "state")),
     type = NULL,
-    rank = NULL,
-    alias = NULL)
+    arrays = NULL)
   options <- list()
 
   expect_equal(
@@ -83,7 +82,7 @@ test_that("can generate simple expressions involving arithmetic", {
 
 
 test_that("can use functions from the library", {
-  dat <- generate_dust_dat(NULL, NULL, NULL, NULL, NULL)
+  dat <- generate_dust_dat(NULL, NULL, NULL, NULL)
   options <- list()
   expect_equal(
     generate_dust_sexp(quote(3 * exp(1 + 2)), dat, options),
@@ -106,8 +105,7 @@ test_that("can coerce to different types", {
       e = "data"),
     packing = list(state = parse_packing("a", NULL, NULL, "state")),
     type = NULL,
-    rank = NULL,
-    alias = NULL)
+    arrays = NULL)
   options <- list()
   expect_equal(
     generate_dust_sexp(quote(a + as.integer(b)), dat, NULL),
@@ -130,8 +128,7 @@ test_that("can generate min/max", {
       e = "data"),
     packing = list(state = parse_packing("a", NULL, NULL, "state")),
     type = NULL,
-    rank = NULL,
-    alias = NULL)
+    arrays = NULL)
   options <- list()
   expect_equal(
     generate_dust_sexp(quote(3 * exp(1 + 2)), dat, options),
@@ -146,7 +143,7 @@ test_that("can generate min/max", {
 
 
 test_that("unsupported functions are bugs", {
-  dat <- generate_dust_dat(NULL, NULL, NULL, NULL, NULL)
+  dat <- generate_dust_dat(NULL, NULL, NULL, NULL)
   expect_error(
     generate_dust_sexp(quote(fn(1)), dat, list()),
     "Unhandled function 'fn'",
@@ -155,7 +152,7 @@ test_that("unsupported functions are bugs", {
 
 
 test_that("unsupported types are bugs", {
-  dat <- generate_dust_dat(NULL, NULL, NULL, NULL, NULL)
+  dat <- generate_dust_dat(NULL, NULL, NULL, NULL)
   expect_error(
     generate_dust_sexp(NULL, dat, list()),
     "Unhandled data type while generating expression",

--- a/tests/testthat/test-generate.R
+++ b/tests/testthat/test-generate.R
@@ -2307,3 +2307,27 @@ test_that("can generate code for array parameter constraints", {
       '  dust2::r::check_max_array<real_type>(shared.r, 2, "r");',
       "}"))
 })
+
+
+test_that("Can read parameters into var with aliased dimension", {
+  dat <- odin_parse({
+    update(x[]) <- x[i] + a
+    initial(x[]) <- x0[i]
+
+    dim(x) <- dim(x0)
+    dim(x0) <- n_x
+    x0 <- parameter()
+    n_x <- parameter()
+    a <- parameter()
+  })
+
+  dat <- generate_prepare(dat)
+  expect_equal(
+    generate_dust_system_update(dat),
+    c(method_args$update,
+      "  const auto * x = state + 0;",
+      "  for (size_t i = 1; i <= shared.dim.x0.size; ++i) {",
+      "    state_next[i - 1 + 0] = x[i - 1] + shared.a;",
+      "  }",
+      "}"))
+})

--- a/tests/testthat/test-parse.R
+++ b/tests/testthat/test-parse.R
@@ -231,7 +231,6 @@ test_that("pack system entirely composed of arrays", {
                rank = 1,
                dims = I(list(list(2), list(2))),
                size = I(list(2, 2)),
-               alias = c("x", "y"),
                offset = I(list(0, 2))))
 })
 
@@ -250,7 +249,25 @@ test_that("pack system of mixed arrays and scalars", {
                rank = c(1, 0),
                dims = I(list(list(2), NULL)),
                size = I(list(2, 1)),
-               alias = c("x", "y"),
+               offset = I(list(0, 2))))
+})
+
+
+test_that("resolve array aliases when building pack", {
+  d <- odin_parse({
+    initial(x[]) <- 1
+    update(x[]) <- x[i] * 2
+    initial(y[]) <- 1
+    update(y[]) <- y[i] / x[i]
+    dim(x) <- 2
+    dim(y) <- dim(x)
+  })
+  expect_equal(
+    d$storage$packing$state,
+    data_frame(name = c("x", "y"),
+               rank = c(1, 1),
+               dims = I(list(list(2), list(2))),
+               size = I(list(2, 2)),
                offset = I(list(0, 2))))
 })
 


### PR DESCRIPTION
Originally I thought the issue was we needed more from the real arrays, so pulled these through the generation (replacing rank and array).  This certainly made things nicer but does not fix the bug (see first commit, 3cf7b42177ce08b0b070852796a195b8359c0515).

The actual error comes from how we compute the pack, and not having `size` and `dim` filled in within the arrays.  I've done that as part of the pack processing (b2824aac5dfcb05b9e567ff954bd9411b6a6c277). With that in, the test passes.