### PR TITLE
Fixes for adjoint model generation

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,7 +17,7 @@ URL: https://mrc-ide.github.io/odin2, https://github.com/mrc-ide/odin2
 BugReports: https://github.com/mrc-ide/odin2/issues
 Imports:
     cli,
-    dust2 (>= 0.3.0),
+    dust2 (>= 0.3.5),
     glue,
     monty (>= 0.3.0),
     rlang

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: odin2
 Title: Next generation odin
-Version: 0.3.2
+Version: 0.3.3
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Wes", "Hinsley", role = "aut"),

--- a/R/generate_dust.R
+++ b/R/generate_dust.R
@@ -568,6 +568,7 @@ generate_dust_system_adjoint_update <- function(dat) {
             "internal_state&" = "internal",
             "real_type*" = "adjoint_next")
   body <- collector()
+  options <- list(stochastic_expectation = TRUE)
 
   unpack <- intersect(dat$variables, dat$adjoint$update$unpack)
   body$add(
@@ -580,8 +581,9 @@ generate_dust_system_adjoint_update <- function(dat) {
                          "adjoint"))
   eqs <- c(get_phase_equations("update", dat, adjoint = TRUE),
            dat$adjoint$update$adjoint)
+
   for (eq in eqs) {
-    body$add(generate_dust_assignment(eq, "adjoint_next", dat))
+    body$add(generate_dust_assignment(eq, "adjoint_next", dat, options))
   }
 
   cpp_function("void", "adjoint_update", args, body$get(), static = TRUE)
@@ -597,6 +599,7 @@ generate_dust_system_adjoint_compare_data <- function(dat) {
             "internal_state&" = "internal",
             "real_type*" = "adjoint_next")
   body <- collector()
+  options <- list(stochastic_expectation = TRUE)
 
   unpack <- intersect(dat$variables, dat$adjoint$compare$unpack)
   body$add(
@@ -611,7 +614,7 @@ generate_dust_system_adjoint_compare_data <- function(dat) {
   eqs <- c(get_phase_equations("compare", dat, adjoint = TRUE),
            dat$adjoint$compare$adjoint)
   for (eq in eqs) {
-    body$add(generate_dust_assignment(eq, "adjoint_next", dat))
+    body$add(generate_dust_assignment(eq, "adjoint_next", dat, options))
   }
 
   cpp_function("void", "adjoint_compare_data", args, body$get(), static = TRUE)
@@ -626,6 +629,7 @@ generate_dust_system_adjoint_initial <- function(dat) {
             "internal_state&" = "internal",
             "real_type*" = "adjoint_next")
   body <- collector()
+  options <- list(stochastic_expectation = TRUE)
 
   unpack <- intersect(dat$variables, dat$adjoint$initial$unpack)
   body$add(
@@ -640,7 +644,7 @@ generate_dust_system_adjoint_initial <- function(dat) {
   eqs <- c(get_phase_equations("initial", dat, adjoint = TRUE),
            dat$adjoint$initial$adjoint)
   for (eq in eqs) {
-    body$add(generate_dust_assignment(eq, "adjoint_next", dat))
+    body$add(generate_dust_assignment(eq, "adjoint_next", dat, options))
   }
 
   cpp_function("void", "adjoint_initial", args, body$get(), static = TRUE)

--- a/R/generate_dust_sexp.R
+++ b/R/generate_dust_sexp.R
@@ -2,6 +2,9 @@ generate_dust_sexp <- function(expr, dat, options = list()) {
   if (is.recursive(expr)) {
     is_stochastic_call <- rlang::is_call(expr[[1]], "OdinStochasticCall")
     if (is_stochastic_call) {
+      if (isTRUE(options$stochastic_expectation)) {
+        return(generate_dust_sexp(expr[[1]]$mean, dat, options))
+      }
       fn <- expr[[1]]$sample
     } else {
       fn <- as.character(expr[[1]])

--- a/R/parse_adjoint.R
+++ b/R/parse_adjoint.R
@@ -104,15 +104,16 @@ adjoint_uses <- function(phase, equations, deps) {
 
 adjoint_phase <- function(eqs, dat) {
   uses <- unique(
-    unlist0(lapply(eqs, function(x) find_dependencies(x)$variables)))
+    unlist0(lapply(eqs, function(x) find_dependencies(x$rhs$expr)$variables)))
 
   ## This is a bit gross; we need to find all variables referenced in
   ## all equations referenced in all adjoint calculations!
   uses_in_equations <- unlist0(
     lapply(dat$equations[intersect(names(dat$equations), uses)],
            function(x) x$rhs$depends$variables))
+  uses <- union(uses, uses_in_equations)
 
-  unpack <- intersect(dat$variables, union(uses, uses_in_equations))
+  unpack <- intersect(dat$variables, uses)
   ## Alternatively, filter *to* things in stack/internal?
   ignore <- c(dat$storage$contents$shared,
               dat$storage$contents$data,

--- a/R/parse_adjoint.R
+++ b/R/parse_adjoint.R
@@ -121,13 +121,14 @@ adjoint_phase <- function(eqs, dat) {
   equations <- setdiff(intersect(names(dat$equations), uses), ignore)
   location <- set_names(vcapply(eqs, function(x) x$lhs$location),
                         vcapply(eqs, function(x) x$lhs$name))
+  include_adjoint <- names(location) %in% uses
 
   unpack_adjoint <- intersect(names(location)[location == "adjoint"], uses)
   list(unpack = unpack,
        unpack_adjoint = unpack_adjoint,
        equations = equations,
-       adjoint = eqs,
-       location = location)
+       adjoint = eqs[include_adjoint],
+       location = location[include_adjoint])
 }
 
 

--- a/tests/testthat/test-generate-adjoint.R
+++ b/tests/testthat/test-generate-adjoint.R
@@ -95,7 +95,6 @@ test_that("can generate adjoint model", {
       "  const real_type noise = 1 / shared.exp_noise;",
       "  const real_type lambda = cases_inc + noise;",
       "  const real_type adj_lambda = data.incidence / lambda - 1;",
-      "  const real_type adj_noise = adj_lambda;",
       "  adjoint_next[0] = adj_S;",
       "  adjoint_next[1] = adj_I;",
       "  adjoint_next[2] = adj_R;",

--- a/tests/testthat/test-generate-adjoint.R
+++ b/tests/testthat/test-generate-adjoint.R
@@ -1,0 +1,107 @@
+test_that("can generate adjoint model", {
+  dat <- odin_parse({
+    initial(S) <- N - I0
+    initial(I) <- I0
+    initial(R) <- 0
+    initial(cases_inc, zero_every = 1) <- 0
+    update(S) <- S - n_SI
+    update(I) <- I + n_SI - n_IR
+    update(R) <- R + n_IR
+    update(cases_inc) <- cases_inc + n_SI
+    n_SI <- Binomial(S, p_SI)
+    n_IR <- Binomial(I, p_IR)
+    p_SI <- 1 - exp(-beta * I / N * dt)
+    p_IR <- 1 - exp(-gamma * dt)
+    beta <- parameter(differentiate = TRUE)
+    gamma <- parameter(differentiate = TRUE)
+    I0 <- parameter(differentiate = TRUE)
+    N <- parameter(1000)
+    exp_noise <- parameter(1e6)
+    incidence <- data()
+    noise <- Exponential(rate = exp_noise)
+    lambda <- cases_inc + noise
+    incidence ~ Poisson(lambda)
+  })
+
+  dat <- generate_prepare(dat)
+
+  expect_equal(
+    generate_dust_system_packing_gradient(dat),
+    c(method_args$packing_gradient,
+      "  return dust2::packing{",
+      '    {"beta", {}},',
+      '    {"gamma", {}},',
+      '    {"I0", {}}',
+      "  };",
+      "}"))
+
+  expect_equal(
+    generate_dust_system_adjoint_update(dat),
+    c(method_args$adjoint_update,
+      "  const auto S = state[0];",
+      "  const auto I = state[1];",
+      "  const auto adj_S = adjoint[0];",
+      "  const auto adj_I = adjoint[1];",
+      "  const auto adj_R = adjoint[2];",
+      "  const auto adj_cases_inc = adjoint[3];",
+      "  const auto adj_beta = adjoint[4];",
+      "  const auto adj_gamma = adjoint[5];",
+      "  const auto adj_I0 = adjoint[6];",
+      "  const real_type p_SI = 1 - monty::math::exp(-shared.beta * I / shared.N * dt);",
+      "  const real_type p_IR = 1 - monty::math::exp(-shared.gamma * dt);",
+      "  const real_type adj_n_IR = -adj_I + adj_R;",
+      "  const real_type adj_n_SI = -adj_S + adj_I + adj_cases_inc;",
+      "  const real_type adj_p_IR = adj_n_IR * I;",
+      "  const real_type adj_p_SI = adj_n_SI * S;",
+      "  adjoint_next[0] = adj_S + adj_n_SI * p_SI;",
+      "  adjoint_next[1] = adj_I + adj_n_IR * p_IR + adj_p_SI * shared.beta * dt * monty::math::exp(-shared.beta * I * dt / shared.N) / shared.N;",
+      "  adjoint_next[2] = adj_R;",
+      "  adjoint_next[3] = adj_cases_inc;",
+      "  adjoint_next[4] = adj_p_SI * I * dt * monty::math::exp(-shared.beta * I * dt / shared.N) / shared.N + adj_beta;",
+      "  adjoint_next[5] = adj_p_IR * dt * monty::math::exp(-shared.gamma * dt) + adj_gamma;",
+      "  adjoint_next[6] = adj_I0;",
+      "}"))
+
+  expect_equal(
+    generate_dust_system_adjoint_initial(dat),
+    c(method_args$adjoint_initial,
+      "  const auto adj_S = adjoint[0];",
+      "  const auto adj_I = adjoint[1];",
+      "  const auto adj_R = adjoint[2];",
+      "  const auto adj_cases_inc = adjoint[3];",
+      "  const auto adj_beta = adjoint[4];",
+      "  const auto adj_gamma = adjoint[5];",
+      "  const auto adj_I0 = adjoint[6];",
+      "  adjoint_next[0] = adj_S;",
+      "  adjoint_next[1] = adj_I;",
+      "  adjoint_next[2] = adj_R;",
+      "  adjoint_next[3] = adj_cases_inc;",
+      "  adjoint_next[4] = adj_beta;",
+      "  adjoint_next[5] = adj_gamma;",
+      "  adjoint_next[6] = -adj_S + adj_I + adj_I0;",
+      "}"))
+
+  expect_equal(
+    generate_dust_system_adjoint_compare_data(dat),
+    c(method_args$adjoint_compare_data,
+      "  const auto cases_inc = state[3];",
+      "  const auto adj_S = adjoint[0];",
+      "  const auto adj_I = adjoint[1];",
+      "  const auto adj_R = adjoint[2];",
+      "  const auto adj_cases_inc = adjoint[3];",
+      "  const auto adj_beta = adjoint[4];",
+      "  const auto adj_gamma = adjoint[5];",
+      "  const auto adj_I0 = adjoint[6];",
+      "  const real_type noise = 1 / shared.exp_noise;",
+      "  const real_type lambda = cases_inc + noise;",
+      "  const real_type adj_lambda = data.incidence / lambda - 1;",
+      "  const real_type adj_noise = adj_lambda;",
+      "  adjoint_next[0] = adj_S;",
+      "  adjoint_next[1] = adj_I;",
+      "  adjoint_next[2] = adj_R;",
+      "  adjoint_next[3] = adj_lambda + adj_cases_inc;",
+      "  adjoint_next[4] = adj_beta;",
+      "  adjoint_next[5] = adj_gamma;",
+      "  adjoint_next[6] = adj_I0;",
+      "}"))
+})


### PR DESCRIPTION
Follows https://github.com/mrc-ide/dust2/pull/136 as I tried to compile a model that included random number draws (the `exp_noise` part of the usual SIR model).  I then hit a constellation of bugs:

* we were not including `noise` within the equations for the compare, because we did not consider recursive dependencies
* we did not take the expectation of stochastic functions
* we included adjoint equations that never appear in the final calculation because they get zeroed

With this (and the dust PR), we can compile a model that corresponds to the SIR model in the fitting vignette but using zero_every:

```r
    initial(S) <- N - I0
    initial(I) <- I0
    initial(R) <- 0
    initial(cases_inc, zero_every = 1) <- 0
    update(S) <- S - n_SI
    update(I) <- I + n_SI - n_IR
    update(R) <- R + n_IR
    update(cases_inc) <- cases_inc + n_SI
    n_SI <- Binomial(S, p_SI)
    n_IR <- Binomial(I, p_IR)
    p_SI <- 1 - exp(-beta * I / N * dt)
    p_IR <- 1 - exp(-gamma * dt)
    beta <- parameter(differentiate = TRUE)
    gamma <- parameter(differentiate = TRUE)
    I0 <- parameter(differentiate = TRUE)
    N <- parameter(1000)
    exp_noise <- parameter(1e6)
    incidence <- data()
    noise <- Exponential(rate = exp_noise)
    lambda <- cases_inc + noise
    incidence ~ Poisson(lambda)
```

~Possibly this makes most sense to merge after the dust2 one with the required version number for dust2 increased~