### PR TITLE
Fix use of array without index in compare

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: odin2
 Title: Next generation odin
-Version: 0.3.8
+Version: 0.3.9
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Wes", "Hinsley", role = "aut"),

--- a/R/parse.R
+++ b/R/parse.R
@@ -142,6 +142,9 @@ parse_check_consistent_dimensions <- function(dat, call) {
     if (!is.null(eq$rhs)) {
       parse_check_consistent_dimensions_rhs(eq, dat, call)
     }
+    if (identical(eq$rhs$type, "compare")) {
+      parse_check_consistent_dimensions_compare(eq, dat, call)
+    }
   }
 }
 
@@ -166,7 +169,8 @@ parse_check_consistent_dimensions_lhs <- function(eq, dat, call, src = eq$src) {
   check(eq$lhs)
 }
 
-parse_check_consistent_dimensions_rhs <- function(eq, dat, call, src = eq$src) {
+
+parse_check_consistent_dimensions_expr <- function(expr, src, dat, call) {
   throw_mismatch <- function(var, dim_rank, array_rank) {
     odin_parse_error(
       c("Array rank in expression differs from the rank declared with `dim`",
@@ -258,5 +262,15 @@ parse_check_consistent_dimensions_rhs <- function(eq, dat, call, src = eq$src) {
       }
     }
   }
-  check(eq$rhs$expr)
+  check(expr)
+}
+
+parse_check_consistent_dimensions_rhs <- function(eq, dat, call) {
+  parse_check_consistent_dimensions_expr(eq$rhs$expr, eq$src, dat, call)
+}
+
+
+parse_check_consistent_dimensions_compare <- function(eq, dat, call) {
+  lapply(eq$rhs$args, parse_check_consistent_dimensions_expr,
+         eq$src, dat, call)
 }

--- a/R/parse_expr.R
+++ b/R/parse_expr.R
@@ -679,10 +679,11 @@ parse_expr_compare_rhs <- function(rhs, src, call) {
   density <- list(cpp = result$value$cpp$density,
                   expr = result$value$expr$density,
                   args = names(formals(result$value$density)))
+  args <- lapply(result$value$args, parse_expr_usage, src, call)
 
   list(type = "compare",
        density = density,
-       args = result$value$args,
+       args = args,
        depends = depends)
 }
 

--- a/tests/testthat/test-parse-expr.R
+++ b/tests/testthat/test-parse-expr.R
@@ -700,3 +700,11 @@ test_that("length is treated as special dependency", {
   res <- parse_expr(quote(dim(a) <- length(b)), NULL, NULL)
   expect_equal(res$rhs$depends$variables, "dim_b")
 })
+
+
+test_that("parse sum within compare", {
+  res <- parse_expr(quote(d ~ Poisson(sum(y))), NULL, NULL)
+  expect_equal(res$rhs$args,
+               list(quote(d),
+                    quote(OdinReduce("sum", "y", index = NULL))))
+})

--- a/tests/testthat/test-parse.R
+++ b/tests/testthat/test-parse.R
@@ -1131,6 +1131,20 @@ test_that("prevent use of arrays without braces", {
 })
 
 
+test_that("prevent use of arrays without index in compare", {
+  ## Found by Keith:
+  expect_error(
+    odin_parse({
+      update(y[]) <- y[i] + 1
+      initial(y[]) <- 0
+      dim(y) <- 2
+      d <- data()
+      d ~ Poisson(y)
+    }),
+    "Trying to use vector 'y' without index")
+})
+
+
 test_that("can't reference data in print", {
   expect_error(
     odin_parse({


### PR DESCRIPTION
Fix for two bugs in compare reported by @KeithJF82:

Previously produced c++ compiler error when we passed the `incidence` vector as a scalar:

```r
ex <- odin({
  update(incidence[]) <- incidence[i] + 1
  initial(incidence[], zero_every = 1) <- 0
  dim(incidence) <- 2
  cases <- data()
  cases ~ Poisson(incidence)
})
```

Previously failed in an odin assertion because we never converted `sum` to `OdinReduce` when parsing the expression:

```
ex <- odin({
  update(incidence[]) <- incidence[i] + 1
  initial(incidence[], zero_every = 1) <- 0
  dim(incidence) <- 2
  cases <- data()
  cases ~ Poisson(sum(incidence))
})
```