### PR TITLE
Add log-normal and weibull

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: odin2
 Title: Next generation odin
-Version: 0.3.13
+Version: 0.3.14
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Wes", "Hinsley", role = "aut"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: odin2
 Title: Next generation odin
-Version: 0.3.12
+Version: 0.3.13
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Wes", "Hinsley", role = "aut"),

--- a/vignettes/functions.Rmd
+++ b/vignettes/functions.Rmd
@@ -278,6 +278,7 @@ The currently supported distributions are (alphabetically):
   - `shape`, `rate` (**default**)
   - `shape`, `scale`
 * `Hypergeometric` -- the [hypergeometric distribution](https://en.wikipedia.org/wiki/Hypergeometric_distribution) with parameters `m` (number of white balls), `n` (number of black balls), and `k` (number of samples), and we return the number of *white* balls.  We may support alternative parametrisations of this distribution in future (this version is the same parametrisation as `rhyper`)
+* `LogNormal` -- the [log-normal distribution](https://en.wikipedia.org/wiki/Log-normal_distribution) with parameters `meanlog` and `sdlog`, the mean and standard deviation of the distribution on the log scale
 * `NegativeBinomial` -- the [negative binomial distribution](https://en.wikipedia.org/wiki/Negative_binomial_distribution) with two forms:
   - `size`, `prob` (**default**)
   - `size`, `mu` (the mean)
@@ -285,6 +286,7 @@ The currently supported distributions are (alphabetically):
 * `Poisson` -- the [Poisson distribution](https://en.wikipedia.org/wiki/Poisson_distribution) with parameter `lambda` (the mean)
 * `TruncatedNormal` -- the [truncated normal distribution](https://en.wikipedia.org/wiki/Truncated_normal_distribution) with parameters `mean`, `sd`, `min` and `max`. For a one-sided truncated normal distribution, you can set `min = -Inf` or `max = Inf`. Note that `mean` and `sd` are not the mean and standard deviation of the truncated normal distribution, but are the mean and standard deviation of the normal distribution that has been truncated.
 * `Uniform` -- the [uniform distribution](https://en.wikipedia.org/wiki/Uniform_distribution) with parameters `min` and `max`
+* `Weibull` -- the [Weibull distribution](https://en.wikipedia.org/wiki/Weibull_distribution) with parameters `shape` and `scale`
 
 In the future, we plan support for additional distributions, please let us know if we are missing any that you need.  The support for these functions comes from `monty` and we will link here to the docs in that package once they exist for additional details.
 

--- a/vignettes/migrating.Rmd
+++ b/vignettes/migrating.Rmd
@@ -224,7 +224,7 @@ The mapping is:
 
 * `rbeta()` to `Beta`
 * `rbinom()` to `Binomial`
-* `rcauchy()` to `Cauchy` (unsupported for now)
+* `rcauchy()` to `Cauchy`
 * `rchisq()` to `ChiSquared` (unsupported for now)
 * `rexp()` to `Exponential`
 * `rf()` to `F` (unsupported for now)
@@ -232,13 +232,13 @@ The mapping is:
 * `rgeometric()` to `Geometric` (unsupported for now)
 * `rhyper()` to `Hypergeometric`
 * `rlogis()` to `Logistic` (unsupported for now)
-* `rlnorm()` to `Lognormal` (unsupported for now)
+* `rlnorm()` to `LogNormal`
 * `rnbinom()` to `NegativeBinomial`
 * `rnorm()` to `Normal`
 * `rpois()` to `Poisson`
 * `rt()` to `T` (unsupported for now)
 * `runif()` to `Uniform`
-* `rweibull()` to `Weibull` (unsupported for now)
+* `rweibull()` to `Weibull`
 
 (Not all of these are implemented yet).
 


### PR DESCRIPTION
Updating docs following `Weibull` and `LogNormal` being added in monty (and also `Cauchy`, which was still listed as "unsupported" in the migration vignette).