### PR TITLE
Lookup args from density

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: odin2
 Title: Next generation odin
-Version: 0.3.12
+Version: 0.3.13
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Wes", "Hinsley", role = "aut"),

--- a/R/parse_expr.R
+++ b/R/parse_expr.R
@@ -900,7 +900,7 @@ parse_expr_usage_rewrite_stochastic <- function(expr, src, call) {
   mean <- substitute_(
     res$value$expr$mean,
     set_names(lapply(args, rewrite_stochastic_to_expectation),
-              names(formals(res$value$sample))[-1]))
+              names(formals(res$value$density))[-1]))
 
   expr[[1]] <- call("OdinStochasticCall",
                     sample = res$value$cpp$sample,


### PR DESCRIPTION
The latest merge on monty caused `sample` in each distribution to change from being a function to the name of a function, latter of which is not in scope unless monty is already attached - which it's not when running all the tests, unless we put library(monty) in each test...

This change looks it up from density, which is still (at present) a function - with the right number of args still? Hopefully enough to point to a better answer if this isn't the best one...!

(codecov failing...)