### PR TITLE
Fix error while generating odin model

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: odin2
 Title: Next generation odin
-Version: 0.3.14
+Version: 0.3.15
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Wes", "Hinsley", role = "aut"),

--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -3,9 +3,12 @@ find_dependencies <- function(expr) {
   variables <- collector()
   descend <- function(e) {
     if (is.recursive(e)) {
-      nm <- deparse(e[[1L]])
-      functions$add(nm)
-      if (nm %in% c("length", "dim") && length(e) == 2 && is.symbol(e[[2]])) {
+      if (rlang::is_call(e) && is.symbol(e[[1]])) {
+        functions$add(deparse(e[[1L]]))
+      }
+      is_dim_read <- rlang::is_call(e, c("length", "dim")) &&
+        length(e) == 2 && is.symbol(e[[2]])
+      if (is_dim_read) {
         variables$add(odin_dim_name(deparse(e[[2]])))
       } else {
         for (el in as.list(e[-1])) {

--- a/tests/testthat/test-dependencies.R
+++ b/tests/testthat/test-dependencies.R
@@ -41,3 +41,17 @@ test_that("can join dependencies", {
     list(functions = c("a", "f", "g", "h", "i"),
          variables = c("a", "b", "c", "d", "e")))
 })
+
+
+test_that("cope with poorly deparsing epxressions", {
+  expr <- quote(
+    OdinStochasticCall(
+      sample = "binomial",
+      mean = S_leave[i, j, k] * (S_rates[i, j, k, 1] / S_leave_rate[i, j, k])
+    )(S_leave[i, j, k], S_rates[i, j, k, 1]/S_leave_rate[i, j, k]))
+  res <- find_dependencies(expr)
+  expect_setequal(res$functions, c("[", "/"))
+  expect_setequal(
+    res$variables,
+    c("S_leave", "i", "j", "k", "S_rates", "S_leave_rate"))
+})


### PR DESCRIPTION
This PR fixes the error seen by Debbie - it's not terribly obvious at first:

```
      nm <- deparse(e[[1L]])
      ...
      if (nm %in% c("length", "dim") && length(e) == 2 && is.symbol(e[[2]])) {
```

this produces a length 2 logical where `deparse` returns a length 2 vector. We assume it won't do that because normally we use it on sensible calls. However we also use this in the generation phase where we just want to peek into the rhs to see which index variables (`i`, `j`, `k` etc) we use and by that time we've rewritten binomial draws as

```
OdinStochasticCall(sample = "binomial", mean = S_leave[i, j, 
    k] * (S_rates[i, j, k, 1]/S_leave_rate[i, j, k]))(S_leave[i, 
    j, k], S_rates[i, j, k, 1]/S_leave_rate[i, j, k])
```

but here the "function name" (the thing called), is `OdinStochasticCall(sample = "binomial", mean = S_leave[i, j, k] * (S_rates[i, j, k, 1]/S_leave_rate[i, j, k]))` which flows onto two lines in `deparse`...
