### PR TITLE
Allow output(x) <- TRUE syntax

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: odin2
 Title: Next generation odin
-Version: 0.3.17
+Version: 0.3.18
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Wes", "Hinsley", role = "aut"),

--- a/R/generate_dust.R
+++ b/R/generate_dust.R
@@ -406,8 +406,7 @@ generate_dust_system_output <- function(dat) {
   unpack <- intersect(dat$variables, dat$phases$output$unpack)
   body$add(
     generate_dust_unpack(unpack, dat$storage$packing$state, dat$sexp_data))
-  eqs <- c(get_phase_equations("output", dat),
-           dat$phases$output$variables)
+  eqs <- get_phase_equations("output", dat)
   for (eq in eqs) {
     body$add(generate_dust_assignment(eq, "state", dat))
   }

--- a/R/parse.R
+++ b/R/parse.R
@@ -20,8 +20,8 @@ odin_parse_quo <- function(quo, input_type, compatibility, call) {
   delays <- parse_system_delays(
     equations, system$ode_variables, system$arrays, call)
   phases <- parse_system_phases(
-    system$exprs, equations, system$variables, system$parameters, delays,
-    system$data$name, call)
+    system$exprs, equations, system$variables, system$output,
+    system$parameters, delays, system$data$name, call)
 
   if (!is.null(delays)) {
     delays$in_rhs <- delays$name %in% phases$deriv$equations

--- a/R/parse_compat.R
+++ b/R/parse_compat.R
@@ -250,7 +250,7 @@ parse_compat_fix_output_self <- function(expr, call) {
     rlang::is_call(expr$value[[2]], "output") &&
     !isTRUE(expr$value[[3]])
   if (is_output_expr) {
-    lhs <- expr$value[[2]]
+    lhs <- expr$value[[2]][[2]]
     rhs <- expr$value[[3]]
     rewrite <-
       (is.symbol(lhs) &&
@@ -261,10 +261,10 @@ parse_compat_fix_output_self <- function(expr, call) {
        identical(lhs[[2]], rhs[[2]]))
     if (rewrite) {
       original <- expr$value
-      if (is_call(lhs, "[[")) {
-        expr$value[[2]] <- expr$value[[2]][[2]]
-      }
       expr$value[[3]] <- TRUE
+      if (rlang::is_call(lhs, "[")) {
+        expr$value[[2]][[2]] <- lhs[[2]]
+      }
       expr <- parse_add_compat(expr, "output_self", original)
     }
   }

--- a/R/parse_system.R
+++ b/R/parse_system.R
@@ -237,11 +237,6 @@ parse_system_overall <- function(exprs, call) {
   } else {
     exprs_output <-
       equations[vcapply(equations, function(x) x$lhs$name) %in% output]
-    ## If this assertion holds, then we can drop changes around here
-    ## and return this simpler expression. However, I don't think it's
-    ## quite as simple as this because in the flag case we don't
-    ## really have that expression to work with.
-    ## stopifnot(identical(exprs_output, exprs[is_output]))
   }
 
   exprs <- list(equations = equations,

--- a/R/parse_system.R
+++ b/R/parse_system.R
@@ -142,21 +142,6 @@ parse_system_overall <- function(exprs, call) {
     is_output_flag <- vlapply(exprs[is_output], function(x) isTRUE(x$rhs$expr))
     is_output_expr <- !is_output_flag
 
-    nms <- lapply(exprs[is_output], function(x) x$lhs$name)
-    nms_flag <- unlist0(nms[is_output_flag])
-    nms_expr <- unique(unlist0(nms[is_output_expr]))
-
-    dups <- union(unique(nms_flag[duplicated(nms_flag)]),
-                  intersect(nms_flag, nms_expr))
-
-    if (length(dups) > 0) {
-      err <- vlapply(nms, function(x) any(dups %in% nms))
-      src <- lapply(exprs[err], "[[", "src")
-      odin_parse_error(
-        "Duplicated output expressions for '{squote(dups)}'",
-        "E2099", src, call)
-    }
-
     ## Rewrite expressions in output(x) <- expr style to just drop the
     ## special output bit now, and treat them as normal expressions.
     if (any(is_output_expr)) {

--- a/R/parse_system.R
+++ b/R/parse_system.R
@@ -458,6 +458,10 @@ parse_system_phases <- function(exprs, equations, variables, output,
   phase_names <- c("update", "deriv", "output", "initial", "compare")
   phases <- set_names(vector("list", length(phase_names)), phase_names)
 
+  if (length(output) > 0) {
+    variables <- setdiff(variables, output)
+  }
+
   for (phase in phase_names) {
     e <- exprs[[phase]]
     if (length(e) > 0) {
@@ -487,6 +491,9 @@ parse_system_phases <- function(exprs, equations, variables, output,
                         "is not allowed because data are not defined",
                         "at this point")),
             "E2010", src, call)
+        }
+        if (phase == "output") {
+          eqs_time <- setdiff(eqs_time, output)
         }
         phases[[phase]] <- list(unpack = unpack,
                                 equations = eqs_time,

--- a/R/parse_system.R
+++ b/R/parse_system.R
@@ -141,6 +141,7 @@ parse_system_overall <- function(exprs, call) {
 
     is_output_flag <- vlapply(exprs[is_output], function(x) isTRUE(x$rhs$expr))
     is_output_expr <- !is_output_flag
+    nms <- lapply(exprs[is_output], function(x) x$lhs$name)
 
     ## Rewrite expressions in output(x) <- expr style to just drop the
     ## special output bit now, and treat them as normal expressions.
@@ -644,7 +645,8 @@ parse_system_arrays <- function(exprs, call) {
     err <- vlapply(exprs[i], function(x) {
       is.null(x$lhs$array) &&
         !identical(x$special, "parameter") &&
-        !identical(x$special, "delay")
+        !identical(x$special, "delay") &&
+        !(identical(x$special, "output") && isTRUE(x$rhs$expr))
     })
     if (any(err)) {
       src <- lapply(exprs[i][err], "[[", "src")

--- a/R/parse_system.R
+++ b/R/parse_system.R
@@ -492,12 +492,18 @@ parse_system_phases <- function(exprs, equations, variables, output,
                         "at this point")),
             "E2010", src, call)
         }
+        ## Output variables are different because they are both
+        ## written to and read from so we treat them more like
+        ## equations here.
         if (phase == "output") {
-          eqs_time <- setdiff(eqs_time, output)
+          eqs_time <- intersect(names(equations), c(eqs_time, output))
+          vars <- list()
+        } else {
+          vars <- e
         }
         phases[[phase]] <- list(unpack = unpack,
                                 equations = eqs_time,
-                                variables = e)
+                                variables = vars)
       } else if (phase == "initial") {
         ## TODO: also need to guard against use of data within this
         ## phase, but that's the case in all phases other than compare

--- a/tests/testthat/test-generate.R
+++ b/tests/testthat/test-generate.R
@@ -2805,3 +2805,23 @@ test_that("output <- TRUE version generates same code", {
 
   expect_equal(generate_dust_system(dat2), generate_dust_system(dat1))
 })
+
+
+test_that("cope with array output", {
+  dat1 <- odin_parse({
+    initial(x[]) <- 0
+    deriv(x[]) <- x[i]
+    a[] <- x[i] + 1
+    output(a) <- TRUE
+    dim(x, a) <- 5
+  })
+
+  dat2 <- odin_parse({
+    initial(x[]) <- 0
+    deriv(x[]) <- x[i]
+    output(a[]) <- x[i] + 1
+    dim(x, a) <- 5
+  })
+
+  expect_equal(generate_dust_system(dat2), generate_dust_system(dat1))
+})

--- a/tests/testthat/test-generate.R
+++ b/tests/testthat/test-generate.R
@@ -2779,3 +2779,29 @@ test_that("correct packing with aliased arrays", {
       "  return shared_state{odin, dim, x, y};",
       "}"))
 })
+
+
+test_that("output <- TRUE version generates same code", {
+  dat1 <- odin_parse({
+    initial(x[]) <- 0
+    deriv(x[]) <- x[i] * r[i]
+    r <- parameter()
+    n <- 3
+    dim(x) <- n
+    dim(r) <- n
+    output(tot) <- sum(x)
+  })
+
+  dat2 <- odin_parse({
+    initial(x[]) <- 0
+    deriv(x[]) <- x[i] * r[i]
+    r <- parameter()
+    n <- 3
+    dim(x) <- n
+    dim(r) <- n
+    tot <- sum(x)
+    output(tot) <- TRUE
+  })
+
+  expect_equal(generate_dust_system(dat2), generate_dust_system(dat1))
+})

--- a/tests/testthat/test-parse-compat.R
+++ b/tests/testthat/test-parse-compat.R
@@ -294,3 +294,30 @@ test_that("disallow parsing interpolation to slice", {
                "Drop arrays from lhs of assignments from 'interpolate()'",
                fixed = TRUE)
 })
+
+
+test_that("warn about old-style output assignments", {
+  w <- expect_warning(
+    odin_parse({
+      initial(x) <- 0
+      deriv(x) <- 1
+      a <- x + 1
+      output(a) <- a
+    }),
+    "Use `TRUE` on rhs for 'output(x) <- x' expressions",
+    fixed = TRUE)
+})
+
+
+test_that("warn about old-style output assignments in arrays", {
+  w <- expect_warning(
+    odin_parse({
+      initial(x) <- 0
+      deriv(x) <- 1
+      a[] <- x + 1
+      output(a[]) <- a[i]
+      dim(a) <- 1
+    }),
+    "Use `TRUE` on rhs for 'output(x) <- x' expressions",
+    fixed = TRUE)
+})

--- a/tests/testthat/test-parse-expr.R
+++ b/tests/testthat/test-parse-expr.R
@@ -708,3 +708,14 @@ test_that("parse sum within compare", {
                list(quote(d),
                     quote(OdinReduce("sum", "y", index = NULL))))
 })
+
+
+test_that("parse output", {
+  res <- parse_expr(quote(output(x) <- TRUE), NULL, NULL)
+  expect_equal(res$lhs$name, "x")
+  expect_equal(res$rhs$expr, TRUE)
+
+  res <- parse_expr(quote(output(x) <- 2 * y), NULL, NULL)
+  expect_equal(res$lhs$name, "x")
+  expect_equal(res$rhs$expr, quote(2 * y))
+})

--- a/tests/testthat/test-parse.R
+++ b/tests/testthat/test-parse.R
@@ -1251,3 +1251,18 @@ test_that("allow reuse of output variables", {
   expect_equal(dat$phases$output$equations, c("a", "b"))
   expect_equal(dat$phases$output$variables, list())
 })
+
+
+## This is not the ideal error, we can put in a special check for this
+## later perhaps.  However, sorting out arrays currently happens
+## before we start breaking apartthe system, which is where
+test_that("disallow use of both forms of output", {
+  expect_error(
+    odin_parse({
+      initial(x) <- 1
+      deriv(x) <- 2
+      output(y) <- x
+      output(y) <- TRUE
+    }),
+    "Only arrays can be assigned over multiple statements")
+})

--- a/tests/testthat/test-parse.R
+++ b/tests/testthat/test-parse.R
@@ -1230,3 +1230,28 @@ test_that("disallow empty index on rhs", {
     }),
     "Can't use the range operator `:` while accessing arrays on the rhs")
 })
+
+
+## In this case, we need to allow for the equations to be put in the
+## correct graph order!
+test_that("allow reuse of output variables", {
+  dat <- odin_parse({
+    initial(x) <- 0
+    deriv(x) <- x / a + b
+    a <- sqrt(x)
+    b <- a + 1
+    output(a) <- TRUE
+    output(b) <- TRUE
+  })
+
+  expect_equal(dat$phases$deriv$unpack, "x")
+  expect_equal(dat$phases$deriv$equations, c("a", "b"))
+  expect_length(dat$phases$deriv$variables, 1)
+  expect_equal(dat$phases$deriv$variables[[1]]$lhs$name, "x")
+
+  expect_equal(dat$phases$output$unpack, "x")
+  expect_equal(dat$phases$output$equations, character())
+  expect_length(dat$phases$output$variables, 2)
+  expect_equal(dat$phases$output$variables[[1]]$lhs$name, "a")
+  expect_equal(dat$phases$output$variables[[2]]$lhs$name, "b")
+})

--- a/tests/testthat/test-parse.R
+++ b/tests/testthat/test-parse.R
@@ -1232,8 +1232,6 @@ test_that("disallow empty index on rhs", {
 })
 
 
-## In this case, we need to allow for the equations to be put in the
-## correct graph order!
 test_that("allow reuse of output variables", {
   dat <- odin_parse({
     initial(x) <- 0
@@ -1250,8 +1248,6 @@ test_that("allow reuse of output variables", {
   expect_equal(dat$phases$deriv$variables[[1]]$lhs$name, "x")
 
   expect_equal(dat$phases$output$unpack, "x")
-  expect_equal(dat$phases$output$equations, character())
-  expect_length(dat$phases$output$variables, 2)
-  expect_equal(dat$phases$output$variables[[1]]$lhs$name, "a")
-  expect_equal(dat$phases$output$variables[[2]]$lhs$name, "b")
+  expect_equal(dat$phases$output$equations, c("a", "b"))
+  expect_equal(dat$phases$output$variables, list())
 })

--- a/vignettes/functions.Rmd
+++ b/vignettes/functions.Rmd
@@ -38,7 +38,7 @@ where `b` will be an entry from data (introduced by `data()`), `Distribution` wi
 Conceptually, a system is entirely determined by its **variables**; these are the state of the system.
 
 * for continuous time (ODE) models, these are the equations that you have time derivatives for, represented by `deriv()` on the left-hand-side of an assignment
-* for discrete time models, these are the equations that you have `update()` equations for, for describing the recurrence equation.
+* for discrete time models, these are the equations that you have `update()` expressions for, for describing the recurrence relation.
 
 Practically, we actually determine the variables of a system based on the presence of an `initial()` call on the left hand side, as this will be present for both continuous-time and discrete-time systems.
 

--- a/vignettes/functions.Rmd
+++ b/vignettes/functions.Rmd
@@ -33,6 +33,53 @@ where `b` will be an entry from data (introduced by `data()`), `Distribution` wi
 
 `odin2` supports many functions that you'd expect to see for constructing dynamical models.  These include most common mathematical operations and some that are quite obscure.  The support for stochastic models and comparison to data comes from `monty`.
 
+# Variables
+
+Conceptually, a system is entirely determined by its **variables**; these are the state of the system.
+
+* for continuous time (ODE) models, these are the equations that you have time derivatives for, represented by `deriv()` on the left-hand-side of an assignment
+* for discrete time models, these are the equations that you have `update()` equations for, for describing the recurrence equation.
+
+Practically, we actually determine the variables of a system based on the presence of an `initial()` call on the left hand side, as this will be present for both continuous-time and discrete-time systems.
+
+The simplest ODE system might be:
+
+```r
+deriv(x) <- 1 / x
+initial(x) <- 1
+```
+
+which describes some sort of logarithmic growth in `x`.
+
+Similarly, a trivial discrete-time system might be
+
+```r
+update(x) <- x + 1
+initial(x) <- 0
+```
+
+which describes a counter.
+
+## Continous time models
+
+There are two special considerations for ODE models.
+
+First, we allow additional "variables" as output; these are quantities for which you do not have derivatives and are computed from your true variables and other quantities in the model, but which are considered state for the purposes of input and output.  You can specify output by writing:
+
+```r
+output(y) <- x * 2
+```
+
+which would define a new variable `y` which takes on the value of `x * 2`.  When passing state into or out of a system `y` would be included even though it is computable from `x`.  Alternatively, if `y` is something that you are already using within the model you can write:
+
+```r
+output(y) <- TRUE
+```
+
+You may want to use these to inspect intermediates in an ODE model, or to reduce the amount of state you need to save from `simulate` etc (for example you may want to output the sum over some disaggregated set of variables for which you actually have derivatives).
+
+Second, if your system has delays, then there is implicit state in the history of these delays.  Delays start off life empty and are filled up as the system runs.  This means that continuing a delayed system is not the same as starting a delayed system from a particular point in space/time, and we will provide tools for working with this in future versions.
+
 # Basic operations
 
 * `+` -- **Plus**: Both infix (`a + b`) and prefix (`+a`) versions supported (e.g., `1 + 2` &rarr; `3`)


### PR DESCRIPTION
This PR restores support for odin1's old syntax for outputting a variable that was used in an intermediate calculation.  We can write:

```r
x <- a + 2
output(x) <- TRUE
```

and also use `x` within calculations in the graph  This was very fiddly to get right in the end, but the overall implementation seems ok.  Doubtless there will be corner cases to catch.

This only affects ODE models so won't affect many people, but is required to support the deterministic malaria model, which is my target to support for replacing odin1