### PR TITLE
Add dim to reserved prefixes

### DIFF
--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -4,9 +4,10 @@ on:
   push:
     branches: [main, master]
   pull_request:
-    branches: [main, master]
 
-name: test-coverage
+name: test-coverage.yaml
+
+permissions: read-all
 
 jobs:
   test-coverage:
@@ -15,7 +16,7 @@ jobs:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: r-lib/actions/setup-r@v2
         with:
@@ -23,28 +24,39 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::covr
+          extra-packages: any::covr, any::xml2
           needs: coverage
 
       - name: Test coverage
         run: |
-          covr::codecov(
+          cov <- covr::package_coverage(
             quiet = FALSE,
             clean = FALSE,
-            install_path = file.path(Sys.getenv("RUNNER_TEMP"), "package")
+            install_path = file.path(normalizePath(Sys.getenv("RUNNER_TEMP"), winslash = "/"), "package")
           )
+          print(cov)
+          covr::to_cobertura(cov)
         shell: Rscript {0}
+
+      - uses: codecov/codecov-action@v5
+        with:
+          # Fail if error if not on PR, or if on PR and token is given
+          fail_ci_if_error: ${{ github.event_name != 'pull_request' || secrets.CODECOV_TOKEN }}
+          files: ./cobertura.xml
+          plugins: noop
+          disable_search: true
+          token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Show testthat output
         if: always()
         run: |
           ## --------------------------------------------------------------------
-          find ${{ runner.temp }}/package -name 'testthat.Rout*' -exec cat '{}' \; || true
+          find '${{ runner.temp }}/package' -name 'testthat.Rout*' -exec cat '{}' \; || true
         shell: bash
 
       - name: Upload test results
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coverage-test-failures
           path: ${{ runner.temp }}/package

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: odin2
 Title: Next generation odin
-Version: 0.3.19
+Version: 0.3.20
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Wes", "Hinsley", role = "aut"),

--- a/R/constants.R
+++ b/R/constants.R
@@ -259,7 +259,7 @@ RESERVED_ODIN <- c(
 
 RESERVED <- sort(unique(c(RESERVED_ODIN, RESERVED_CPP, RESERVED_JS)))
 
-RESERVED_ODIN_PREFIX <- c("odin", "interpolate", "delay", "adjoint")
+RESERVED_ODIN_PREFIX <- c("odin", "dim", "interpolate", "delay", "adjoint")
 RESERVED_ODIN_PREFIX_RE <- sprintf("^(%s)_.*",
                                    paste(RESERVED_ODIN_PREFIX, collapse = "|"))
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <!-- badges: start -->
 [![Project Status: WIP – Initial development is in progress, but there has not yet been a stable, usable release suitable for the public.](https://www.repostatus.org/badges/latest/wip.svg)](https://www.repostatus.org/#wip)
 [![R build status](https://github.com/mrc-ide/odin2/workflows/R-CMD-check/badge.svg)](https://github.com/mrc-ide/odin2/actions)
-[![codecov.io](https://codecov.io/github/mrc-ide/odin2/coverage.svg?branch=main)](https://codecov.io/github/mrc-ide/odin2?branch=main)
+[![Codecov test coverage](https://codecov.io/gh/mrc-ide/odin2/graph/badge.svg)](https://app.codecov.io/gh/mrc-ide/odin2)
 <!-- badges: end -->
 
 `odin2` implements a high-level language for describing and implementing ordinary differential equations and difference equations in R.  It provides a "[domain specific language](https://en.wikipedia.org/wiki/Domain-specific_language)" (DSL) which _looks_ like R but is compiled directly to C++, using [`dust2`](https://mrc-ide.github.io/dust2/) to solve your system and to provide an interface to particle filters.  You can then use [`monty`](https://mrc-ide.github.io/monty/) to fit your models using MCMC.

--- a/tests/testthat/test-parse-expr.R
+++ b/tests/testthat/test-parse-expr.R
@@ -461,6 +461,8 @@ test_that("Can't assign to names with reserved prefixes", {
                "Invalid name 'odin_x' starts with reserved prefix 'odin'")
   expect_error(parse_expr(quote(adjoint_x <- 1), NULL, NULL),
                "Invalid name 'adjoint_x' starts with reserved prefix 'adjoint'")
+  expect_error(parse_expr(quote(dim_x <- 1), NULL, NULL),
+               "Invalid name 'dim_x' starts with reserved prefix 'dim'")
 })
 
 

--- a/vignettes/functions.Rmd
+++ b/vignettes/functions.Rmd
@@ -436,4 +436,4 @@ You cannot assign to a name that is reserved in:
 * [JavaScript](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#reserved_words) - includes useful words such as `default` and `export`
 * A few words restricted by odin itself: `time`, `dt`, `parameter`, `data`, `interpolate`, `delay`, `initial`, `deriv`, `update`, `output`, `dim`, `config`, `state`, `state_next`, `state_deriv`, `shared`, `internal`, `pi`.  We may reduce this list in future.
 
-In addition, odin restricts a few prefixes; a name cannot start with `odin_`, `interpolate_`, `delay_` or `adjoint_`.
+In addition, odin restricts a few prefixes; a name cannot start with `odin_`, `dim_`, `interpolate_`, `delay_` or `adjoint_`.


### PR DESCRIPTION
Adds `dim_` to the reserved prefix list - this was enforced in odin1 too.

Fixes #140 