### PR TITLE
Prevent expressions involving literal integers being treated as integer division

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: odin2
 Title: Next generation odin
-Version: 0.3.20
+Version: 0.3.21
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Wes", "Hinsley", role = "aut"),

--- a/tests/testthat/test-generate-dust-sexp.R
+++ b/tests/testthat/test-generate-dust-sexp.R
@@ -36,6 +36,16 @@ test_that("can generate integer maths functions", {
 })
 
 
+test_that("can generate robust code for division", {
+  dat <- generate_dust_dat(c(a = "shared", b = "stack"), NULL, NULL, NULL)
+  options <- list()
+  expect_equal(generate_dust_sexp(quote(a / b), dat, options),
+               "shared.a / b")
+  expect_equal(generate_dust_sexp(quote(1 / 2), dat, options),
+               "static_cast<real_type>(1) / 2")
+})
+
+
 test_that("can cast types", {
   dat <- generate_dust_dat(c(a = "shared"), NULL, NULL, NULL)
   options <- list()


### PR DESCRIPTION
See #142 for context.  We treat `1 / 2` as an integer division, truncating to zero; this PR fixes this by detecting when this would occur. Most commonly seen in argument defaults but possible elsewhere too

Fixes #142 