### PR TITLE
Fix generation of browser export

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: odin2
 Title: Next generation odin
-Version: 0.3.21
+Version: 0.3.22
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Wes", "Hinsley", role = "aut"),

--- a/R/generate_dust.R
+++ b/R/generate_dust.R
@@ -947,12 +947,13 @@ generate_dust_browser <- function(dat, phase) {
 
 generate_dust_browser_to_env <- function(name, dat, env) {
   data <- generate_dust_sexp(name, dat$sexp_data)
-  if (name %in% dat$storage$arrays$name) {
+  arrays <- dat$storage$arrays
+  if (name %in% arrays$name) {
     location <- dat$storage$location[[name]]
     if (location %in% c("shared", "internal")) {
       data <- sprintf("%s.data()", data)
     }
-    dim <- sprintf("shared.dim.%s", name)
+    dim <- sprintf("shared.dim.%s", arrays$alias[match(name, arrays$name)])
     sprintf('dust2::r::browser::save(%s, %s, "%s", %s);', data, dim, name, env)
   } else {
     sprintf('dust2::r::browser::save(%s, "%s", %s);', data, name, env)

--- a/R/generate_dust.R
+++ b/R/generate_dust.R
@@ -922,13 +922,13 @@ generate_dust_browser <- function(dat, phase) {
                                 dat$sexp_data))
   env <- "odin_env"
   body$add(sprintf("auto %s = dust2::r::browser::create();", env))
-  ## TODO: don't drop 'data' if using browser in compare, but think
-  ## about how probabilities might be surfaced.
+
   type <- dat$storage$type
-  location <- dat$storage$type
-  export <- intersect(
-    names(location[location != "data"]),
-    names(type[type %in% c("real_type", "int", "bool")]))
+  export <- intersect(c(dat$phases$build_shared$equations,
+                        dat$phases$update_shared$equations,
+                        dat$phases[[phase]]$equations,
+                        dat$variables),
+                      names(type)[type %in% c("real_type", "int", "bool")])
   for (v in c("time", export)) {
     body$add(generate_dust_browser_to_env(v, dat, env))
   }

--- a/tests/testthat/test-generate.R
+++ b/tests/testthat/test-generate.R
@@ -2339,9 +2339,9 @@ test_that("can generate browser code", {
       "  if (time > 2) {",
       "    auto odin_env = dust2::r::browser::create();",
       '    dust2::r::browser::save(time, "time", odin_env);',
-      '    dust2::r::browser::save(x, "x", odin_env);',
       '    dust2::r::browser::save(a, "a", odin_env);',
       '    dust2::r::browser::save(b, "b", odin_env);',
+      '    dust2::r::browser::save(x, "x", odin_env);',
       '    dust2::r::browser::enter(odin_env, "update", time);',
       "  }",
       "}"))
@@ -2373,9 +2373,9 @@ test_that("can dereference array dimension alias in browser", {
       "  const auto x = state[0];",
       "  auto odin_env = dust2::r::browser::create();",
       '  dust2::r::browser::save(time, "time", odin_env);',
-      '  dust2::r::browser::save(x, "x", odin_env);',
       '  dust2::r::browser::save(internal.a.data(), shared.dim.a, "a", odin_env);',
       '  dust2::r::browser::save(internal.b.data(), shared.dim.a, "b", odin_env);',
+      '  dust2::r::browser::save(x, "x", odin_env);',
       '  dust2::r::browser::enter(odin_env, "update", time);',
       "}"))
 })
@@ -2423,9 +2423,6 @@ test_that("can generate nontrivial debug", {
       "  if (I < 10 && time > 20) {",
       "    auto odin_env = dust2::r::browser::create();",
       '    dust2::r::browser::save(time, "time", odin_env);',
-      '    dust2::r::browser::save(S, "S", odin_env);',
-      '    dust2::r::browser::save(I, "I", odin_env);',
-      '    dust2::r::browser::save(R, "R", odin_env);',
       '    dust2::r::browser::save(shared.N, "N", odin_env);',
       '    dust2::r::browser::save(shared.beta, "beta", odin_env);',
       '    dust2::r::browser::save(shared.gamma, "gamma", odin_env);',
@@ -2434,6 +2431,9 @@ test_that("can generate nontrivial debug", {
       '    dust2::r::browser::save(p_SI, "p_SI", odin_env);',
       '    dust2::r::browser::save(n_SI, "n_SI", odin_env);',
       '    dust2::r::browser::save(n_IR, "n_IR", odin_env);',
+      '    dust2::r::browser::save(S, "S", odin_env);',
+      '    dust2::r::browser::save(I, "I", odin_env);',
+      '    dust2::r::browser::save(R, "R", odin_env);',
       '    dust2::r::browser::enter(odin_env, "update", time);',
       "  }",
       "}"))
@@ -2468,9 +2468,9 @@ test_that("browse with arrays", {
       "  }",
       "  auto odin_env = dust2::r::browser::create();",
       '  dust2::r::browser::save(time, "time", odin_env);',
-      '  dust2::r::browser::save(x, shared.dim.x, "x", odin_env);',
       '  dust2::r::browser::save(internal.a.data(), shared.dim.a, "a", odin_env);',
       '  dust2::r::browser::save(internal.b.data(), shared.dim.b, "b", odin_env);',
+      '  dust2::r::browser::save(x, shared.dim.x, "x", odin_env);',
       '  dust2::r::browser::enter(odin_env, "update", time);',
       "}"))
 })

--- a/tests/testthat/test-generate.R
+++ b/tests/testthat/test-generate.R
@@ -2858,3 +2858,29 @@ test_that("cope with array output", {
 
   expect_equal(generate_dust_system(dat2), generate_dust_system(dat1))
 })
+
+
+test_that("correctly use browser in system with compare", {
+  dat <- odin_parse({
+    a <- Uniform(0, 1)
+    b <- Normal(0, 1)
+    initial(x) <- 0
+    update(x) <- x + a
+    browser(phase = "update")
+    d ~ Normal(b, x)
+    d <- data()
+  })
+  dat <- generate_prepare(dat)
+  expect_equal(
+    generate_dust_system_update(dat),
+    c(method_args$update,
+      "  const auto x = state[0];",
+      "  const real_type a = monty::random::uniform<real_type>(rng_state, 0, 1);",
+      "  state_next[0] = x + a;",
+      "  auto odin_env = dust2::r::browser::create();",
+      '  dust2::r::browser::save(time, "time", odin_env);',
+      '  dust2::r::browser::save(a, "a", odin_env);',
+      '  dust2::r::browser::save(x, "x", odin_env);',
+      '  dust2::r::browser::enter(odin_env, "update", time);',
+      "}"))
+})


### PR DESCRIPTION
Reported by @ruthmccabe, two bugs in generating code for `browser()`:

* aliased dimensions were not treated properly, trying to access the apparent (rather than real underlying) dimension
* expressions that are time-dependent but used only in compare were being exported incorrectly