### PR TITLE
Better checking of arguments to interpolate

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: odin2
 Title: Next generation odin
-Version: 0.3.23
+Version: 0.3.24
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Wes", "Hinsley", role = "aut"),

--- a/R/parse_array_bounds.R
+++ b/R/parse_array_bounds.R
@@ -107,9 +107,9 @@ parse_array_bounds_extract_constraint_lhs <- function(eq) {
     ## We need to add:
     ## * 1 constraint for length(time) == dim(value, rank)
     ## * n constraints for dim(name, i) == dim(value, i) over all dimensions
-    len_t <- call("OdinDim", value, rank + 1L)
+    len_t <- call("OdinLength", time)
     ret$add(constraint(
-      "interpolate:time", time, expr[[3]], 1L, len_t, TRUE, eq$src$index))
+      "interpolate:time", value, time, rank + 1L, len_t, TRUE, eq$src$index))
     for (i in seq_len(rank)) {
       len_i <- call("OdinDim", value, i)
       ret$add(constraint(
@@ -205,13 +205,10 @@ constraint_triage <- function(d, arrays, equations, variables, src, call) {
     is_interpolate <- startsWith(d$type[[i]], "interpolate:")
 
     if (is_interpolate) {
-      info <- equations[[name]]$rhs$info
-      target <- name
-      value <- info$value
-      time <- info$time
       msg <- "Incompatible size arrays in arguments to 'interpolate()'"
-
       if (d$type[[i]] == "interpolate:time") {
+        time <- d$expr[[1]]
+        value <- name
         time_length <- at_value
         value_length <- size_value
         if (rank == 1) {
@@ -231,6 +228,9 @@ constraint_triage <- function(d, arrays, equations, variables, src, call) {
             "E3002", expr, call)
         }
       } else {
+        info <- equations[[name]]$rhs$info
+        target <- name
+        value <- info$value
         target_length <- size_value
         value_length <- at_value
         odin_parse_error(

--- a/R/parse_system.R
+++ b/R/parse_system.R
@@ -223,6 +223,9 @@ parse_system_overall <- function(exprs, call) {
           rhs = list(type = "expression",
                      expr = call("OdinInterpolateEval",
                                  eq$lhs$name, eq$lhs$name_data),
+                     info = list(rank = eq$rhs$expr$rank,
+                                 time = eq$rhs$expr$time,
+                                 value = eq$rhs$expr$value),
                      depends = list(functions = character(),
                                     variables = eq$lhs$name)),
           src = eq$src)

--- a/tests/testthat/test-parse-array-bounds.R
+++ b/tests/testthat/test-parse-array-bounds.R
@@ -188,30 +188,40 @@ test_that("can deparse constraints", {
 
 
 test_that("solve simple constraints", {
-  expect_equal(constraint_solve(1, 2), list(valid = TRUE))
-  expect_equal(constraint_solve(2, 2), list(valid = TRUE))
-  expect_equal(constraint_solve(2, 1), list(valid = FALSE))
-  expect_equal(constraint_solve(quote(a), quote(a)), list(valid = TRUE))
-  expect_equal(constraint_solve(quote(a + b), quote(a + b)), list(valid = TRUE))
+  expect_equal(constraint_solve(1, 2, FALSE), list(valid = TRUE))
+  expect_equal(constraint_solve(2, 2, FALSE), list(valid = TRUE))
+  expect_equal(constraint_solve(2, 1, FALSE), list(valid = FALSE))
+  expect_equal(constraint_solve(quote(a), quote(a), FALSE),
+               list(valid = TRUE))
+  expect_equal(constraint_solve(quote(a + b), quote(a + b), FALSE),
+               list(valid = TRUE))
 
-  expect_equal(constraint_solve(quote(a - 1), quote(a)), list(valid = TRUE))
-  expect_equal(constraint_solve(quote(a + 1), quote(a)), list(valid = FALSE))
+  expect_equal(constraint_solve(quote(a - 1), quote(a), FALSE),
+               list(valid = TRUE))
+  expect_equal(constraint_solve(quote(a + 1), quote(a), FALSE),
+               list(valid = FALSE))
 
   expect_equal(
-    constraint_solve(quote(OdinParameter("a") - 1), quote(OdinParameter("a"))),
+    constraint_solve(quote(OdinParameter("a") - 1),
+                     quote(OdinParameter("a")),
+                     FALSE),
     list(valid = TRUE))
   expect_equal(
-    constraint_solve(quote(OdinParameter("a") + 1), quote(OdinParameter("a"))),
+    constraint_solve(quote(OdinParameter("a") + 1),
+                     quote(OdinParameter("a")),
+                     FALSE),
     list(valid = FALSE))
   expect_equal(
-    constraint_solve(quote(OdinParameter("a")), quote(OdinParameter("b"))),
+    constraint_solve(quote(OdinParameter("a")),
+                     quote(OdinParameter("b")),
+                     FALSE),
     list(valid = NA,
          constraint = quote(OdinParameter("b") >= OdinParameter("a"))))
 })
 
 
 test_that("tidy expression", {
-  expect_equal(constraint_tidy(quote(a + 1)), quote(a + 1 >= 0))
-  expect_equal(constraint_tidy(quote(-a - 1 + OdinParameter("x"))),
+  expect_equal(constraint_tidy(quote(a + 1), FALSE), quote(a + 1 >= 0))
+  expect_equal(constraint_tidy(quote(-a - 1 + OdinParameter("x")), FALSE),
                quote(OdinParameter("x") >= 1 + a))
 })

--- a/tests/testthat/test-parse.R
+++ b/tests/testthat/test-parse.R
@@ -1328,3 +1328,43 @@ test_that("don't error if array sizes are not provably correct for interp", {
       dim(ay) <- parameter(rank = 3)
     }))
 })
+
+
+test_that("require that time for interpolation is reasonable", {
+  err <- expect_error(
+    odin_parse({
+      initial(y) <- 0
+      update(y) <- a
+      a <- interpolate(at, ay, "constant")
+      at <- parameter()
+      ay <- parameter()
+      dim(at) <- 5
+      dim(ay) <- 6
+    }),
+    "Incompatible size arrays in arguments to 'interpolate()'",
+    fixed = TRUE)
+  expect_match(
+    err$body[[1]],
+    "'ay' must have the same length as 'at'")
+})
+
+
+test_that("require that time for interpolation is reasonable", {
+  err <- expect_error(
+    odin_parse({
+      initial(y[, ]) <- 0
+      update(y[, ]) <- a[i, j]
+      dim(y) <- c(2, 3)
+      a <- interpolate(at, ay, "constant")
+      at <- parameter()
+      ay <- parameter()
+      dim(a) <- c(2, 3)
+      dim(at) <- 5
+      dim(ay) <- c(2, 3, 6)
+    }),
+    "Incompatible size arrays in arguments to 'interpolate()'",
+    fixed = TRUE)
+  expect_match(
+    err$body[[1]],
+    "The last dimension of 'ay' must be the same as the length of 'at'")
+})

--- a/tests/testthat/test-parse.R
+++ b/tests/testthat/test-parse.R
@@ -1266,3 +1266,65 @@ test_that("disallow use of both forms of output", {
     }),
     "Only arrays can be assigned over multiple statements")
 })
+
+
+test_that("can validate interpolation dimensions correctly", {
+  ## This is the expected behaviour, in the output
+  gen <- odin({
+    initial(y[, ]) <- 0
+    update(y[, ]) <- a[i, j]
+    dim(y) <- c(2, 3)
+    a <- interpolate(at, ay, "constant")
+    at <- parameter()
+    ay <- parameter()
+    dim(a) <- c(2, 3)
+    dim(at) <- 5
+    dim(ay) <- c(2, 3, 5)
+  }, debug = TRUE, quiet = TRUE)
+
+  at <- c(0, 4, 8, 12, 16)
+  ay <- array(runif(2 * 3 * 5), c(2, 3, 5))
+  sys <- dust2::dust_system_create(gen, list(at = at, ay = ay))
+  y <- dust2::dust_system_simulate(sys, 0:20)
+
+  yy <- dust2::dust_unpack_state(sys, y)$y
+  expect_equal(yy[, , 1], matrix(0, 2, 3))
+  expect_equal(yy[, , -1], ay[, , rep(1:5, each = 4)])
+})
+
+
+test_that("Can detect errors in array sizes where all are known", {
+  err <- expect_error(
+    odin_parse({
+      initial(y[, ]) <- 0
+      update(y[, ]) <- a[i, j]
+      dim(y) <- c(2, 3)
+      a <- interpolate(at, ay, "constant")
+      at <- parameter()
+      ay <- parameter()
+      dim(a) <- c(2, 3)
+      dim(at) <- 5
+      dim(ay) <- c(5, 2, 3)
+    }),
+    "Incompatible size arrays in arguments to 'interpolate()'",
+    fixed = TRUE)
+  expect_match(
+    err$body[[1]],
+    "The first 2 dimensions of 'ay' must be the same as the dimensions of 'a'")
+})
+
+
+test_that("don't error if array sizes are not provably correct for interp", {
+  expect_no_error(
+    odin_parse({
+      initial(y[, ]) <- 0
+      update(y[, ]) <- a[i, j]
+      dim(y) <- c(2, 3)
+      a <- interpolate(at, ay, "constant")
+      at <- parameter()
+      ay <- parameter()
+      dim(a) <- parameter(rank = 2)
+      dim(at) <- parameter(rank = 1)
+      dim(ay) <- parameter(rank = 3)
+    }))
+})

--- a/vignettes/errors.Rmd
+++ b/vignettes/errors.Rmd
@@ -1255,3 +1255,21 @@ dim(a) <- 4
 because we are accessing `a` at position 5 due to the loop over `x`, but `a` only has 4 elements.
 
 More complex errors are possible, and it may not be possible to obviously reverse odin's chain of logic for deciding an access would be out of bounds; please let us know if you find difficult-to-explain cases and we can use these to try and make it clearer.
+
+# `E3002`
+
+Incompatible sizes in arguments to `interpolate()`.  The array sizes of the arguments and the "target" (the variable on the left hand side), must be compatible with each other.
+
+Consider the expression:
+
+```
+a <- interpolate(b, c, "constant")
+```
+
+The target `a` can be a scalar, vector or higher dimensional object.  The time argument `b` is always a vector (say of length `nt`) and the value `c` has dimensions `c(dim(a), nt)`; that is the dimensions of `a` followed by the number of time elements.
+
+So:
+
+* if `a` is a scalar, then `c` must be a vector of length `nt`
+* If `a` is a vector of length `n1`, then `c` must be a matrix with `n1` rows and `nt` columns
+* If `a` is a matrix with `n1` rows and `n2` columns, then `c` must be a 3-dimensional array with dimensions `c(n1, n2, nt)` and so on


### PR DESCRIPTION
This adds an error message that would have fixed Arran's original problem with interpolation, where the arrays are of incompatible sizes.