### PR TITLE
Validate array access within sum

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: odin2
 Title: Next generation odin
-Version: 0.3.24
+Version: 0.3.25
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Wes", "Hinsley", role = "aut"),

--- a/R/generate_dust_sexp.R
+++ b/R/generate_dust_sexp.R
@@ -238,9 +238,9 @@ flatten_index <- function(idx, name) {
 
 
 generate_dust_sexp_reduce <- function(expr, dat, options) {
-  fn <- expr[[2]]
-  target <- expr[[3]]
-  target_str <- generate_dust_sexp(expr[[3]], dat, options)
+  fn <- expr$fn
+  target <- expr$what
+  target_str <- generate_dust_sexp(target, dat, options)
   if (dat$location[[target]] %in% c("internal", "shared")) {
     target_str <- sprintf("%s.data()", target_str)
   }

--- a/R/parse.R
+++ b/R/parse.R
@@ -256,7 +256,7 @@ parse_check_consistent_dimensions_expr <- function(expr, src, dat, call) {
         lapply(args, check)
       } else if (rlang::is_call(expr, fn_use_whole_array)) {
         if (rlang::is_call(expr, "OdinReduce")) {
-          array_name <- expr[[3]]
+          array_name <- expr$what
           if (!(array_name %in% names(dim_ranks))) {
             throw_no_dim(array_name)
           }

--- a/R/parse_array_bounds.R
+++ b/R/parse_array_bounds.R
@@ -165,10 +165,28 @@ parse_array_bounds_extract_constraint_rhs <- function(eq) {
           warn_unhandled_analysis(expr, uses)
         }
       }
+    } else if (rlang::is_call(expr, "OdinReduce")) {
+      name <- expr$what
+      idx <- expr$index
+      for (i in seq_along(idx)) {
+        for (v in c("from", "to", "at")) {
+          at <- idx[[i]][[v]]
+          if (!is.null(at)) {
+            uses <- intersect(all.vars(at), INDEX)
+            if (length(uses) > 0) {
+              browser()
+              at <- substitute_(at, set_names(idx[v], uses))
+            }
+            ret$add(constraint(
+              "access:read", name, expr$expr[[2]], i, at, FALSE, eq$src$index))
+          }
+        }
+      }
     } else if (is.recursive(expr)) {
       lapply(expr[-1], extract)
     }
   }
+
   extract(eq$rhs$expr)
   ret$get()
 }

--- a/R/parse_expr.R
+++ b/R/parse_expr.R
@@ -917,7 +917,7 @@ parse_expr_usage_rewrite_reduce <- function(expr, src, call) {
   arg <- expr[[2]]
   if (rlang::is_symbol(arg)) {
     name <- as.character(arg)
-    return(call("OdinReduce", fn, name, index = NULL))
+    return(call("OdinReduce", fn = fn, what = name, index = NULL, expr = expr))
   } else if (!rlang::is_call(arg, "[")) {
     odin_parse_error(
       c("Expected argument to '{fn}' to be an array",
@@ -933,7 +933,7 @@ parse_expr_usage_rewrite_reduce <- function(expr, src, call) {
 
   ## Handle special case efficiently:
   if (all(vlapply(index, rlang::is_missing))) {
-    return(call("OdinReduce", fn, name, index = NULL))
+    return(call("OdinReduce", fn = fn, what = name, index = NULL, expr = expr))
   }
 
   for (i in seq_along(index)) {
@@ -954,7 +954,7 @@ parse_expr_usage_rewrite_reduce <- function(expr, src, call) {
     index[[i]] <- v
   }
 
-  call("OdinReduce", fn, name, index = index)
+  call("OdinReduce", fn = fn, what = name, index = index, expr = expr)
 }
 
 

--- a/tests/testthat/test-parse-array-bounds.R
+++ b/tests/testthat/test-parse-array-bounds.R
@@ -225,3 +225,28 @@ test_that("tidy expression", {
   expect_equal(constraint_tidy(quote(-a - 1 + OdinParameter("x")), FALSE),
                quote(OdinParameter("x") >= 1 + a))
 })
+
+
+test_that("can detect out-of-range access in sum()", {
+  expect_error(
+    odin_parse({
+      N[] <- 0
+      dim(N) <- 3
+      update(x) <- a
+      initial(x) <- 0
+      a <- sum(N[5])
+    }),
+    "Out of range read of 'N' in 'N[5]'",
+    fixed = TRUE)
+
+  expect_error(
+    odin_parse({
+      N[] <- 0
+      dim(N) <- 3
+      update(x) <- a
+      initial(x) <- 0
+      a <- sum(N[1:5])
+    }),
+    "Out of range read of 'N' in 'N[1:5]'",
+    fixed = TRUE)
+})


### PR DESCRIPTION
Part of the bug reported by Lilith via Teams, where we never validate array access within `sum()`. Doubtless there will be more to catch here, but this is already useful.

The next part of this is that negative indexing (e.g. `sum(x[-1])`), which is allowed in R, needs also to be prevented