### PR TITLE
Allow min and max to be used with arguments of different types

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: odin2
 Title: Next generation odin
-Version: 0.3.25
+Version: 0.3.26
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Wes", "Hinsley", role = "aut"),

--- a/R/generate_dust_sexp.R
+++ b/R/generate_dust_sexp.R
@@ -135,7 +135,7 @@ generate_dust_sexp <- function(expr, dat, options = list()) {
     } else if (fn %in% c("min", "max")) {
       ## Getting the type here correct is hard because we need to
       ## have both input types be the same (and we will often get
-      ## int/real disagreement) but the reslution of the type should
+      ## int/real disagreement) but the resolution of the type should
       ## depend on how the function is used.  If we are within a `[`
       ## expression then we're almost certainly wanting an integer
       ## out but otherwise we are almost certainly wanting a real

--- a/tests/testthat/test-generate-dust-sexp.R
+++ b/tests/testthat/test-generate-dust-sexp.R
@@ -18,11 +18,24 @@ test_that("can generate min/max expressions", {
   dat <- generate_dust_dat(c(a = "shared", b = "stack"), NULL, NULL, NULL)
   options <- list()
   expect_equal(generate_dust_sexp(quote(min(a, b)), dat, options),
-               "monty::math::min(shared.a, b)")
+               "monty::math::min<real_type>(shared.a, b)")
   expect_equal(generate_dust_sexp(quote(max(a, 1)), dat, options),
-               "monty::math::max(shared.a, static_cast<real_type>(1))")
+               "monty::math::max<real_type>(shared.a, 1)")
   expect_equal(generate_dust_sexp(quote(min(2, 1)), dat, options),
-               "monty::math::min(2, 1)")
+               "monty::math::min<real_type>(2, 1)")
+})
+
+
+test_that("can generate min/max expressions for index", {
+  dat <- generate_dust_dat(c(a = "shared", b = "stack", x = "internal"),
+                           NULL, NULL, NULL)
+  options <- list()
+  expect_equal(generate_dust_sexp(quote(x[min(a, b)]), dat, options),
+               "internal.x[monty::math::min<int>(shared.a, b) - 1]")
+  expect_equal(generate_dust_sexp(quote(x[max(a, 1)]), dat, options),
+               "internal.x[monty::math::max<int>(shared.a, 1) - 1]")
+  expect_equal(generate_dust_sexp(quote(x[min(2, 1)]), dat, options),
+               "internal.x[monty::math::min<int>(2, 1) - 1]")
 })
 
 

--- a/tests/testthat/test-generate.R
+++ b/tests/testthat/test-generate.R
@@ -2262,7 +2262,7 @@ test_that("support min/max", {
   expect_equal(
     generate_dust_system_update(dat),
     c(method_args$update,
-      "  state_next[0] = dust2::array::min<real_type>(shared.a.data(), shared.dim.a) + monty::math::max(shared.b, shared.c);",
+      "  state_next[0] = dust2::array::min<real_type>(shared.a.data(), shared.dim.a) + monty::math::max<real_type>(shared.b, shared.c);",
       "}"))
 })
 


### PR DESCRIPTION
We had some support for `min(x, 1)` where the first argument was `real_type` and the second was a literal integer, but this is just a heuristic - and not always wanted! In the case where `min` or `max` is used as part of an array access we don't want to create a float and then cast that back to `int`. This PR explicitly selects the correct template based on the use of the function, which prevents the compiler error that Ed sees.

Previously, Ed saw:

```
mod <- odin2::odin({
  new_y[x] <- min(y[i] + 1, max_y)
  update(y[]) <- new_y[i]
  initial(y[]) <- 0
  dim(y, new_y) <- n

  update(x) <- if (new_y[x] == max_y) min(x + 1, n) else x
  initial(x) <- 1

  n <- parameter()
  max_y <- parameter()
})
```

produce the error

```
   dust.cpp: In static member function ‘static void odin_system::update(real_type, real_type, const real_type*, const shared_state&, internal_state&, rng_state_type&, real_type*)’:
   dust.cpp:72:78: error: no matching function for call to ‘min(double, const int&)’
      72 |     state_next[0] = (internal.new_y[x - 1] == shared.max_y ? monty::math::min(x + 1, shared.n) : x);
         |                                                              ~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~
   In file included from /home/rfitzjoh/lib/R/library/4.4.2/monty/include/monty/random/exponential.hpp:6,
                    from /home/rfitzjoh/lib/R/library/4.4.2/monty/include/monty/random/gamma.hpp:9,
                    from /home/rfitzjoh/lib/R/library/4.4.2/monty/include/monty/random/beta.hpp:7,
                    from /home/rfitzjoh/lib/R/library/4.4.2/monty/include/monty/random/random.hpp:6,
                    from /home/rfitzjoh/lib/R/library/4.4.2/dust2/include/dust2/common.hpp:5,
                    from dust.cpp:2:
   /home/rfitzjoh/lib/R/library/4.4.2/monty/include/monty/random/math.hpp:408:3: note: candidate: ‘template<class T> T monty::math::min(T, T)’
     408 | T min(T a, T b) {
         |   ^~~
   /home/rfitzjoh/lib/R/library/4.4.2/monty/include/monty/random/math.hpp:408:3: note:   template argument deduction/substitution failed:
   dust.cpp:72:78: note:   deduced conflicting types for parameter ‘T’ (‘double’ and ‘int’)
      72 |     state_next[0] = (internal.new_y[x - 1] == shared.max_y ? monty::math::min(x + 1, shared.n) : x);
                                                              ~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~
   make: *** [/usr/lib64/R/etc/Makeconf:204: dust.o] Error 1
   ERROR: compilation failed for package ‘odin.systemc0709e0a’
─  removing ‘/tmp/RtmplEt4zZ/devtools_install_252de036ddab90/odin.systemc0709e0a’
Error in `(function (command = NULL, args = character(), error_on_status = TRUE, …`:
! System command 'R' failed
```

because `update` contained:

```
static void update(real_type time, real_type dt, const real_type* state, const shared_state& shared, internal_state& internal, rng_state_type& rng_state, real_type* state_next) {
  const auto * y = state + 1;
  const auto x = state[0];
  {
    const size_t i = x;
    internal.new_y[x - 1] = monty::math::min(y[i - 1] + 1, shared.max_y);
  }
  for (size_t i = 1; i <= shared.dim.y.size; ++i) {
    state_next[i - 1 + 1] = internal.new_y[i - 1];
  }
  state_next[0] = (internal.new_y[x - 1] == shared.max_y ? monty::math::min(x + 1, shared.n) : x);
}
```

but with this PR we will now generate

```
static void update(real_type time, real_type dt, const real_type* state, const shared_state& shared, internal_state& internal, rng_state_type& rng_state, real_type* state_next) {
  const auto * y = state + 1;
  const auto x = state[0];
  {
    const size_t i = x;
    internal.new_y[x - 1] = monty::math::min<real_type>(y[i - 1] + 1, shared.max_y);
  }
  for (size_t i = 1; i <= shared.dim.y.size; ++i) {
    state_next[i - 1 + 1] = internal.new_y[i - 1];
  }
  state_next[0] = (internal.new_y[x - 1] == shared.max_y ? monty::math::min<real_type>(x + 1, shared.n) : x);
}
```