### PR TITLE
Fix error while throwing error in parse

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: odin2
 Title: Next generation odin
-Version: 0.3.28
+Version: 0.3.29
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Wes", "Hinsley", role = "aut"),

--- a/R/parse_expr.R
+++ b/R/parse_expr.R
@@ -857,7 +857,7 @@ parse_expr_usage <- function(expr, src, call) {
 }
 
 
-parse_expr_check_call <- function(expr, usage, src, call) {
+parse_expr_check_call <- function(expr, src, call) {
   fn <- as.character(expr[[1]])
   usage <- FUNCTIONS[[fn]]
   if (is.function(usage)) {

--- a/tests/testthat/test-parse.R
+++ b/tests/testthat/test-parse.R
@@ -1379,3 +1379,14 @@ test_that("require that time for interpolation is reasonable", {
     err$body[[1]],
     "The last dimension of 'ay' must be the same as the length of 'at'")
 })
+
+
+test_that("throw incorrect if/else errors correctly", {
+  ## Regression test for bug reported by Ed and Keith
+  expect_error(
+    odin_parse({
+      initial(X) <- 0
+      update(X) <- if (X < 10) X + 1
+    }),
+    "All 'if' statements must have an 'else' clause")
+})


### PR DESCRIPTION
Fixes an error reported by Keith and Ed where this:

```
  initial(X) <- 0
  update(X) <- if (X < 10) X + 1
```

errors unexpectedly with

```
Error in parse_error_src(src) : 
  !any(vlapply(src, function(x) is.null(x$value))) is not TRUE
```

This is because the arguments to `parse_expr_check_call` were out of sync with the call; I am not sure where this was introduced, but we never see it in the tests because most line-level parse errors to not include source information.

