### PR TITLE
Fix error thrown when unknown array index used on lhs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: odin2
 Title: Next generation odin
-Version: 0.3.27
+Version: 0.3.28
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Wes", "Hinsley", role = "aut"),

--- a/R/parse.R
+++ b/R/parse.R
@@ -93,7 +93,10 @@ parse_check_usage_find_unknown <- function(dat, call) {
       })
   }
 
-  unknown <- lapply(eqs, function(eq) setdiff(eq$rhs$depends$variables, known))
+  unknown <- lapply(eqs, function(eq) {
+    used <- c(eq$rhs$depends$variables, eq$lhs$depends$variables)
+    setdiff(used, known)
+  })
 
   err <- lengths(unknown) > 0
   if (!any(err)) {

--- a/tests/testthat/test-parse.R
+++ b/tests/testthat/test-parse.R
@@ -1329,6 +1329,18 @@ test_that("don't error if array sizes are not provably correct for interp", {
 })
 
 
+test_that("sensible error if given invalid array index", {
+  expect_error(
+    odin_parse({
+      a <- parameter(10)
+      initial(X[1:a]) <- 0
+      dim(X) <- a
+      update(X[1:b]) <- X[i]+1
+    }),
+    "Unknown variable used in odin code: 'b'")
+})
+
+
 test_that("require that time for interpolation is reasonable", {
   err <- expect_error(
     odin_parse({


### PR DESCRIPTION
As reported by Keith.  This is only seen when a variable is misspelt on the lhs of an array expression, because we never check them in the dependencies.  The actual error was then thrown later when building constraints, but we never get there now with this fix