### PR TITLE
Fix reset and zero

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: odin2
 Title: Next generation odin
-Version: 0.3.35
+Version: 0.3.36
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Wes", "Hinsley", role = "aut"),

--- a/R/parse.R
+++ b/R/parse.R
@@ -35,7 +35,7 @@ odin_parse_quo <- function(quo, input_type, compatibility, check_bounds, call) {
     equations, phases, system$variables, system$output, system$arrays,
     system$parameters, system$data, delays, call)
   zero_every <- parse_zero_every(system$time, phases, equations,
-                                 system$variables, call)
+                                 system$ode_variables, call)
   print <- parse_print(system$exprs$print, system$time, system$variables,
                        equations, system$data, phases, call)
   browser <- parse_browser(system$exprs$browser, system$time, system$variables,

--- a/R/parse.R
+++ b/R/parse.R
@@ -16,12 +16,15 @@ odin_parse_quo <- function(quo, input_type, compatibility, check_bounds, call) {
 
   exprs <- parse_system_arrays(exprs, call)
   system <- parse_system_overall(exprs, call)
+
+  variables_without_output <- system$ode_variables %||% system$variables
+
   equations <- parse_system_depends(
-    system$exprs$equations, system$ode_variables, call)
+    system$exprs$equations, variables_without_output, call)
   equations <- parse_system_stage(
     equations, system$variables, system$parameters, system$data$name, call)
   delays <- parse_system_delays(
-    equations, system$ode_variables, system$arrays, call)
+    equations, variables_without_output, system$arrays, call)
   phases <- parse_system_phases(
     system$exprs, equations, system$variables, system$output,
     system$parameters, delays, system$data$name, call)
@@ -35,7 +38,7 @@ odin_parse_quo <- function(quo, input_type, compatibility, check_bounds, call) {
     equations, phases, system$variables, system$output, system$arrays,
     system$parameters, system$data, delays, call)
   zero_every <- parse_zero_every(system$time, phases, equations,
-                                 system$ode_variables, call)
+                                 variables_without_output, call)
   print <- parse_print(system$exprs$print, system$time, system$variables,
                        equations, system$data, phases, call)
   browser <- parse_browser(system$exprs$browser, system$time, system$variables,

--- a/tests/testthat/test-parse.R
+++ b/tests/testthat/test-parse.R
@@ -1415,3 +1415,16 @@ test_that("Throw sensible error on invalid call to compare()", {
     "Invalid special function 'compare()' on the lhs of a `~` comparison",
     fixed = TRUE)
 })
+
+
+
+test_that("can parse system that resets and has output", {
+  d <- odin_parse({
+    deriv(x) <- x + 1
+    initial(x, zero_every = 4) <- 0
+    deriv(y) <- y + 1
+    initial(y) <- 0
+    output(z) <- x / y
+  })
+  expect_equal(d$zero_every, list(x = 4))
+})


### PR DESCRIPTION
As seen trying to write some docs about delays.  We need to pass in the variable list *without output* when dealing with the periodically-zero'd variables, otherwise there's a length mismatch resulting in an obscure non-odin error.