### PR TITLE
Add links to the odin-monty book

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: odin2
 Title: Next generation odin
-Version: 0.3.37
+Version: 0.3.38
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Wes", "Hinsley", role = "aut"),

--- a/README.md
+++ b/README.md
@@ -18,11 +18,18 @@
 
 ## Documentation
 
+The best place to start for most people is probably the [odin & monty book](https://mrc-ide.github.io/odin-monty/) which walks through odin and its context within a wider set of statistical packages.
+
+The package also includes a number of vignettes and other documentation:
+
 * See [the introductory vignette](https://mrc-ide.github.io/odin2/articles/odin2.html) for a tutorial-style introduction to `odin2`
 * A [tutorial-style guide](https://mrc-ide.github.io/odin2/articles/fitting.html) to using `odin2` with `dust2` and `monty` to fit models to data
 * A [reference-style guide](https://mrc-ide.github.io/odin2/articles/functions.html) to the syntax and supported functions
 * If you have used [`odin` version 1](https://mrc-ide.github.io/odin) before, see the [migration guide](https://mrc-ide.github.io/odin2/articles/migrating.html) to see what has changed.
-* Because `odin2` compiles to `dust2`, see [its documentation](https://mrc-ide.github.io/dust2) and in particular the [list of functions that you can use](https://mrc-ide.github.io/dust2/reference/index.html)
+
+Because `odin2` compiles to `dust2`, see [its documentation](https://mrc-ide.github.io/dust2) and in particular the [list of functions that you can use](https://mrc-ide.github.io/dust2/reference/index.html)
+
+Because `odin2` is designed for use with `monty`, see [its documentation](https://mrc-ide.github.io/monty/), especially when fitting models to data or working with the random number generators for stochastic models.
 
 ## Roadmap
 

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -15,6 +15,7 @@ dS
 datastream
 discretising
 dt
+erroring
 etc
 frac
 inspectable

--- a/vignettes/odin2.Rmd
+++ b/vignettes/odin2.Rmd
@@ -16,7 +16,7 @@ knitr::opts_chunk$set(
 
 `odin2` implements a high-level language for describing and implementing ordinary differential equations and difference equations in R.  It provides a "[domain specific language](https://en.wikipedia.org/wiki/Domain-specific_language)" (DSL) which _looks_ like R but is compiled directly to C++, using [`dust2`](https://mrc-ide.github.io/dust2/) to solve your system and to provide an interface to particle filters.  You can then use [`monty`](https://mrc-ide.github.io/monty/) to fit your models using MCMC.
 
-This vignette jumps through a few of the core features of `odin2` and ways that you might use it with `dust2` and `monty`.  Other vignettes (when written!) will expand on topics covered here in more detail.
+This vignette jumps through a few of the core features of `odin2` and ways that you might use it with `dust2` and `monty`.  The [other vignettes](https://mrc-ide.github.io/odin2/articles/) and the [odin & monty book](https://mrc-ide.github.io/odin-monty/) expand on topics covered here in more detail.
 
 # Discrete time stochastic SIR model
 


### PR DESCRIPTION
These are missing from the README and intro vignette, but are now the best starting point.