### PR TITLE
Fix interpolate in update shared

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: odin2
 Title: Next generation odin
-Version: 0.3.42
+Version: 0.3.43
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Wes", "Hinsley", role = "aut"),

--- a/R/generate_dust.R
+++ b/R/generate_dust.R
@@ -810,13 +810,12 @@ generate_dust_assignment <- function(eq, name_state, dat, options = list()) {
     }
   } else if (identical(eq$rhs$type, "interpolate")) {
     name <- eq$lhs$name
+    rhs <- generate_dust_sexp(eq$rhs$expr, dat$sexp_data, options)
     if (isFALSE(options$shared_exists)) {
       dest <- name
-      rhs <- generate_dust_sexp(eq$rhs$expr, dat$sexp_data, options)
       res <- sprintf("const auto %s = %s;", dest, rhs)
     } else {
       dest <- sprintf("shared.%s", name)
-      rhs <- generate_dust_sexp(eq$rhs$expr, dat$sexp_data, options)
       res <- sprintf("%s = %s;", dest, rhs)
     }
   } else if (rlang::is_call(eq$rhs$expr, "OdinInterpolateEval") &&

--- a/R/generate_dust.R
+++ b/R/generate_dust.R
@@ -809,8 +809,16 @@ generate_dust_assignment <- function(eq, name_state, dat, options = list()) {
       res <- sprintf("dim.%s.set({%s});", eq$lhs$name_data, dims_str)
     }
   } else if (identical(eq$rhs$type, "interpolate")) {
-    rhs <- generate_dust_sexp(eq$rhs$expr, dat$sexp_data, options)
-    res <- sprintf("const auto %s = %s;", eq$lhs$name, rhs)
+    name <- eq$lhs$name
+    if (isFALSE(options$shared_exists)) {
+      dest <- name
+      rhs <- generate_dust_sexp(eq$rhs$expr, dat$sexp_data, options)
+      res <- sprintf("const auto %s = %s;", dest, rhs)
+    } else {
+      dest <- sprintf("shared.%s", name)
+      rhs <- generate_dust_sexp(eq$rhs$expr, dat$sexp_data, options)
+      res <- sprintf("%s = %s;", dest, rhs)
+    }
   } else if (rlang::is_call(eq$rhs$expr, "OdinInterpolateEval") &&
              eq$lhs$name %in% dat$storage$arrays$name) {
     ## Special case here until we sort out vector valued functions I

--- a/tests/testthat/test-generate.R
+++ b/tests/testthat/test-generate.R
@@ -1900,6 +1900,14 @@ test_that("can add interpolation", {
       "  odin.packing.state.copy_offset(odin.offset.state.begin());",
       "  return shared_state{odin, dim, n, at, ay, interpolate_y};",
       "}"))
+  
+  expect_equal(
+    generate_dust_system_update_shared(dat),
+    c(method_args$update_shared,
+      '  dust2::r::read_real_array(parameters, shared.dim.at, shared.at.data(), "at", false);',               
+      '  dust2::r::read_real_array(parameters, shared.dim.ay, shared.ay.data(), "ay", false);',              
+      '  shared.interpolate_y = dust2::interpolate::InterpolateConstant(shared.at, shared.ay, "at", "ay");',
+      "}" ))
 })
 
 
@@ -2080,6 +2088,14 @@ test_that("can interpolate arrays", {
       "  };",
       "  odin.packing.state.copy_offset(odin.offset.state.begin());",
       "  return shared_state{odin, dim, nt, na, at, ay, interpolate_a};",
+      "}"))
+  
+  expect_equal(
+    generate_dust_system_update_shared(dat),
+    c(method_args$update_shared,
+      '  dust2::r::read_real_array(parameters, shared.dim.at, shared.at.data(), "at", false);',                                               
+      '  dust2::r::read_real_array(parameters, shared.dim.ay, shared.ay.data(), "ay", false);',                                                
+      '  shared.interpolate_a = dust2::interpolate::InterpolateConstantArray<real_type, 1>(shared.at, shared.ay, shared.dim.a, "at", "ay");',
       "}"))
 
   expect_equal(


### PR DESCRIPTION
This should fix a problem where when updating parameters of a system, use of interpolate is not updated.

Best illustrated by a simple example - take this simple model with an interpolate

```
m <- odin2::odin({
  update(x) <- x + a + b
  initial(x) <- 0
  
  b <- parameter()
  a_time <- parameter()
  a_value <- parameter()
  a <- interpolate(a_time, a_value, "constant")
  dim(a_time, a_value) <- parameter(rank = 1)
})
```
then we create a system
```
sys <- dust2::dust_system_create(m, list(a_time = c(0, 1, 2),
                                         a_value = c(1, 2, 3),
                                         b = 1))
dust2::dust_system_set_state_initial(sys)
```
and simulate
```
> dust2::dust_system_simulate(sys, c(1, 2, 3))
     [,1] [,2] [,3]
[1,]    2    5    9
```
This works fine!

Now we try to update the parameters of this existing system (we also need to reset the state and time)
```
dust2::dust_system_update_pars(sys, list(a_time = c(0, 1, 2),
                                         a_value = c(1, 2, 50),
                                         b = 1))
dust2::dust_system_set_state_initial(sys)
dust2::dust_system_set_time(sys, 0)
```
and simulate
```
> dust2::dust_system_simulate(sys, c(1, 2, 3))
     [,1] [,2] [,3]
[1,]    2    5    9
```
we get exactly what we had before - the interpolate has not updated properly.


Seems the issue is that in the generated code we have
```
static void update_shared(cpp11::list parameters, shared_state& shared) {
    shared.b = dust2::r::read_real(parameters, "b", shared.b);
    dust2::r::read_real_array(parameters, shared.dim.a_time, shared.a_time.data(), "a_time", false);
    dust2::r::read_real_array(parameters, shared.dim.a_time, shared.a_value.data(), "a_value", false);
    const auto interpolate_a = dust2::interpolate::InterpolateConstant(shared.a_time, shared.a_value, "a_time", "a_value");
}   
```
where we want (difference is in the interpolate_a line)
```
static void update_shared(cpp11::list parameters, shared_state& shared) {
    shared.b = dust2::r::read_real(parameters, "b", shared.b);
    dust2::r::read_real_array(parameters, shared.dim.a_time, shared.a_time.data(), "a_time", false);
    dust2::r::read_real_array(parameters, shared.dim.a_time, shared.a_value.data(), "a_value", false);
    shared.interpolate_a = dust2::interpolate::InterpolateConstant(shared.a_time, shared.a_value, "a_time", "a_value");
}    
```

Compilation with this fix results in correct behaviour
```
> sys <- dust2::dust_system_create(m, list(a_time = c(0, 1, 2),
+                                          a_value = c(1, 2, 3),
+                                          b = 1))
> dust2::dust_system_set_state_initial(sys)
> dust2::dust_system_simulate(sys, c(1, 2, 3))
     [,1] [,2] [,3]
[1,]    2    5    9
> dust2::dust_system_update_pars(sys, list(a_time = c(0, 1, 2),
+                                          a_value = c(1, 2, 50),
+                                          b = 1))
> dust2::dust_system_set_state_initial(sys)
> dust2::dust_system_set_time(sys, 0)
> dust2::dust_system_simulate(sys, c(1, 2, 3))
     [,1] [,2] [,3]
[1,]    2    5   56
```