### PR TITLE
Fix adjoint_compare_data NaN propagation when data contains NA

### DIFF
--- a/R/generate_dust.R
+++ b/R/generate_dust.R
@@ -647,6 +647,19 @@ generate_dust_system_adjoint_compare_data <- function(dat) {
     body$add(generate_dust_assignment(eq, "adjoint_next", dat, options))
   }
 
+  ## Sanitise NaN values in adjoint_next.  The forward compare_data
+  ## uses unless_nan() to skip density evaluations when data is NA
+  ## (NaN in C++), but the symbolic adjoint expressions reference data
+  ## fields directly (e.g., log(1 - data.cfr)) and produce NaN when
+  ## those data are missing.  Replace any NaN entries with the incoming
+  ## adjoint value, i.e., no contribution from the compare step for
+  ## that variable, matching the forward semantics.
+  body$add(paste0(
+    "const auto n_adj = shared.odin.packing.adjoint.size();"))
+  body$add(paste0(
+    "for (size_t k = 0; k < n_adj; ++k) {",
+    " if (std::isnan(adjoint_next[k])) adjoint_next[k] = adjoint[k]; }"))
+
   cpp_function("void", "adjoint_compare_data", args, body$get(), static = TRUE)
 }
 

--- a/tests/testthat/test-generate-adjoint.R
+++ b/tests/testthat/test-generate-adjoint.R
@@ -155,5 +155,7 @@ test_that("can generate adjoint model", {
       "  adjoint_next[4] = adj_beta;",
       "  adjoint_next[5] = adj_gamma;",
       "  adjoint_next[6] = adj_I0;",
+      "  const auto n_adj = shared.odin.packing.adjoint.size();",
+      "  for (size_t k = 0; k < n_adj; ++k) { if (std::isnan(adjoint_next[k])) adjoint_next[k] = adjoint[k]; }",
       "}"))
 })


### PR DESCRIPTION
## Problem

The forward `compare_data` method uses an `unless_nan()` lambda to skip density evaluations when observed data is `NA` (represented as `NaN` in C++):

```cpp
auto unless_nan = [](real_type x) { return std::isnan(x) ? 0 : x; };
odin_ll += unless_nan(monty::density::poisson(...));
```

However, the symbolic adjoint expressions in `adjoint_compare_data` reference data fields directly (e.g., `data.incidence / lambda`, `log(1 - data.cfr_00_04)`) without any NaN guard. When data fields are `NaN`, these expressions produce `NaN` which propagates through the entire adjoint vector, causing **all gradients to become `NA`**.

## Reproduction

Any model with `has_adjoint = TRUE` and sparse/incomplete data will produce all-`NA` gradients from `dust_likelihood_last_gradient()`. I found this when testing the adjoint on an age-stratified model with many `NA` entries in the observation data.

## Fix

Add a NaN sanitisation loop at the end of `adjoint_compare_data` that replaces any `NaN` in `adjoint_next` with the corresponding incoming `adjoint` value:

```cpp
const auto n_adj = shared.odin.packing.adjoint.size();
for (size_t k = 0; k < n_adj; ++k) {
  if (std::isnan(adjoint_next[k])) adjoint_next[k] = adjoint[k];
}
```

This matches the forward-pass semantics: `NA` data contributes zero to the log-likelihood, and therefore zero to the gradient. The incoming adjoint value is preserved unchanged for any variable whose adjoint expression produced `NaN`.

## Tests

Updated the existing test in `test-generate-adjoint.R` to expect the new sanitisation lines in the generated C++ output. All existing tests pass.