### PR TITLE
Allow multiple print statements

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: odin2
 Title: Next generation odin
-Version: 0.3.43
+Version: 0.3.44
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Wes", "Hinsley", role = "aut"),

--- a/R/parse_expr.R
+++ b/R/parse_expr.R
@@ -797,7 +797,7 @@ parse_expr_browser <- function(expr, src, call) {
   }
 
   phase <- m$value$phase
-  when <- m$value$when
+  when <- parse_expr_usage(m$value$when, src, call)
 
   tryCatch(
     match_value(phase, PHASES_BROWSER),

--- a/R/parse_expr.R
+++ b/R/parse_expr.R
@@ -718,13 +718,15 @@ parse_expr_print <- function(expr, src, call) {
   inputs <- parse_print_string(string, src, call)
   depends <- join_dependencies(
     lapply(inputs, function(x) find_dependencies(x$expr)))
+  
+  when <- parse_expr_usage(m$value$when, src, call)
 
   list(special = "print",
        rhs = list(type = "print"), # makes checking easier elsewhere
        string = string,
        inputs = inputs,
        depends = depends,
-       when = m$value$when,
+       when = when,
        src = src)
 }
 
@@ -753,12 +755,14 @@ parse_print_string <- function(string, src, call) {
   }
 
   lapply(parts, function(p) {
-    tryCatch(
+    x <- tryCatch(
       parse_print_element(p), error = function(e) {
         odin_parse_error(
           "Failed to parse print string '{string}': '{p}' is not valid",
           "E1054", src, call, parent = e)
       })
+    x$expr <- parse_expr_usage(x$expr, src, call)
+    x
   })
 }
 

--- a/R/parse_system.R
+++ b/R/parse_system.R
@@ -712,7 +712,8 @@ parse_system_arrays <- function(exprs, call) {
   ## Need to treat browser here, as the error we get below is poor if
   ## we have multiple browser calls.
   is_browser <- vlapply(exprs, function(x) identical(x$special, "browser"))
-  err <- duplicated(id) & !is_browser
+  is_print <- vlapply(exprs, function(x) identical(x$special, "print"))
+  err <- duplicated(id) & !is_browser & !is_print
   if (any(err)) {
     for (i in unique(id[err])) {
       parse_system_arrays_check_duplicated(id == i, exprs, call)

--- a/tests/testthat/test-generate.R
+++ b/tests/testthat/test-generate.R
@@ -2281,6 +2281,28 @@ test_that("print integers", {
 })
 
 
+test_that("print with min for arrays", {
+  dat <- odin_parse({
+    initial(x[]) <- 1
+    update(x[]) <- x[i] + 1
+    dim(x) <- 5
+    print("min(x): {min(x)}", when = min(x) > 2)
+  })
+  dat <- generate_prepare(dat)
+  expect_equal(
+    generate_dust_system_update(dat),
+    c(method_args$update,
+      "  const auto * x = state + 0;",
+      "  for (size_t i = 1; i <= shared.dim.x.size; ++i) {",
+      "    state_next[i - 1 + 0] = x[i - 1] + 1;",
+      "  }",
+      "  if (dust2::array::min<real_type>(x, shared.dim.x) > 2) {",
+      '    Rprintf(\"[%f] min(x): %f\\n\", time, dust2::array::min<real_type>(x, shared.dim.x));',
+      "  }",
+      "}" ))
+})
+
+
 test_that("support min/max", {
   dat <- odin_parse({
     update(x) <- min(a) + max(b, c)
@@ -2539,6 +2561,31 @@ test_that("browse with arrays", {
       '  dust2::r::browser::save(x, shared.dim.x, "x", odin_env);',
       '  dust2::r::browser::enter(odin_env, "update", time);',
       "}"))
+})
+
+
+test_that("conditional browser using sum/min for arrays", {
+  dat <- odin_parse({
+    initial(x[]) <- 1
+    update(x[]) <- x[i] + 1
+    dim(x) <- 5
+    browser(phase = "update", when = sum(x) - min(x) > 2)
+  })
+  dat <- generate_prepare(dat)
+  expect_equal(
+    generate_dust_system_update(dat),
+    c(method_args$update,
+      "  const auto * x = state + 0;",
+      "  for (size_t i = 1; i <= shared.dim.x.size; ++i) {",
+      "    state_next[i - 1 + 0] = x[i - 1] + 1;",
+      "  }",
+      "  if (dust2::array::sum<real_type>(x, shared.dim.x) - dust2::array::min<real_type>(x, shared.dim.x) > 2) {",
+      "    auto odin_env = dust2::r::browser::create();",
+      "    dust2::r::browser::save(time, \"time\", odin_env);",
+      "    dust2::r::browser::save(x, shared.dim.x, \"x\", odin_env);",
+      "    dust2::r::browser::enter(odin_env, \"update\", time);",
+      "  }",
+      "}" ))
 })
 
 

--- a/tests/testthat/test-parse-system.R
+++ b/tests/testthat/test-parse-system.R
@@ -312,6 +312,18 @@ test_that("work out correct print phase", {
   expect_equal(names(res$print), "deriv")
 })
 
+test_that("can use multiple print statements", {
+  res <- odin_parse({
+    update(a) <- 1
+    initial(a) <- 1
+    update(b) <- 2
+    initial(b) <- 2
+    print("{a}")
+    print("{b}")
+  })
+  expect_equal(length(res$print$update$equations), 2)
+})
+
 
 test_that("parse a very simple delay", {
   dat <- odin_parse({


### PR DESCRIPTION
Currently if you include multiple print statements in odin code you get an error, e.g.

```
odin({
  update(x) <- x + 1
  update(y) <- (x + 1)^2
  
  initial(x) <- 0
  initial(y) <- 0
  
  print("x: {x}", when = x > 2)
  print("y: {y}", when = y > 16)
})
```
results in the error
```
Error in `odin2::odin()`:
! Only arrays can be assigned over multiple statements, but '' is assigned as a symbol
→ Context:
print("x: {x}", when = x > 2)
print("y: {y}", when = y > 16)
ℹ For more information, run odin2::odin_error_explain("E2012")
```

There's no reason why we can't have multiple print statements, which is particularly useful for having different prints triggered by different `when` conditions.

With the fix in this PR, the model successfully compiles
```
m <- odin({
  update(x) <- x + 1
  update(y) <- (x + 1)^2
  
  initial(x) <- 0
  initial(y) <- 0
  
  print("x: {x}", when = x > 2)
  print("y: {y}", when = y > 16)
})
```
and we can run it

```
sys <- dust2::dust_system_create(m)
dust2::dust_system_set_state_initial(sys)
res <- dust2::dust_system_simulate(sys, seq_len(10))
```

giving
```
> res <- dust2::dust_system_simulate(sys, seq_len(10))
[3.000000] x: 3.000000
[4.000000] x: 4.000000
[5.000000] x: 5.000000
[5.000000] y: 25.000000
[6.000000] x: 6.000000
[6.000000] y: 36.000000
[7.000000] x: 7.000000
[7.000000] y: 49.000000
[8.000000] x: 8.000000
[8.000000] y: 64.000000
[9.000000] x: 9.000000
[9.000000] y: 81.000000
```