### PR TITLE
Allow min (and max/sum/prod) for arrays in print/browser

### DIFF
--- a/R/parse_expr.R
+++ b/R/parse_expr.R
@@ -797,7 +797,7 @@ parse_expr_browser <- function(expr, src, call) {
   }
 
   phase <- m$value$phase
-  when <- m$value$when
+  when <- parse_expr_usage(m$value$when, src, call)
 
   tryCatch(
     match_value(phase, PHASES_BROWSER),

--- a/R/parse_expr.R
+++ b/R/parse_expr.R
@@ -718,13 +718,15 @@ parse_expr_print <- function(expr, src, call) {
   inputs <- parse_print_string(string, src, call)
   depends <- join_dependencies(
     lapply(inputs, function(x) find_dependencies(x$expr)))
+  
+  when <- parse_expr_usage(m$value$when, src, call)
 
   list(special = "print",
        rhs = list(type = "print"), # makes checking easier elsewhere
        string = string,
        inputs = inputs,
        depends = depends,
-       when = m$value$when,
+       when = when,
        src = src)
 }
 
@@ -753,12 +755,14 @@ parse_print_string <- function(string, src, call) {
   }
 
   lapply(parts, function(p) {
-    tryCatch(
+    x <- tryCatch(
       parse_print_element(p), error = function(e) {
         odin_parse_error(
           "Failed to parse print string '{string}': '{p}' is not valid",
           "E1054", src, call, parent = e)
       })
+    x$expr <- parse_expr_usage(x$expr, src, call)
+    x
   })
 }
 

--- a/tests/testthat/test-generate.R
+++ b/tests/testthat/test-generate.R
@@ -2281,6 +2281,28 @@ test_that("print integers", {
 })
 
 
+test_that("print with min for arrays", {
+  dat <- odin_parse({
+    initial(x[]) <- 1
+    update(x[]) <- x[i] + 1
+    dim(x) <- 5
+    print("min(x): {min(x)}", when = min(x) > 2)
+  })
+  dat <- generate_prepare(dat)
+  expect_equal(
+    generate_dust_system_update(dat),
+    c(method_args$update,
+      "  const auto * x = state + 0;",
+      "  for (size_t i = 1; i <= shared.dim.x.size; ++i) {",
+      "    state_next[i - 1 + 0] = x[i - 1] + 1;",
+      "  }",
+      "  if (dust2::array::min<real_type>(x, shared.dim.x) > 2) {",
+      '    Rprintf(\"[%f] min(x): %f\\n\", time, dust2::array::min<real_type>(x, shared.dim.x));',
+      "  }",
+      "}" ))
+})
+
+
 test_that("support min/max", {
   dat <- odin_parse({
     update(x) <- min(a) + max(b, c)
@@ -2539,6 +2561,31 @@ test_that("browse with arrays", {
       '  dust2::r::browser::save(x, shared.dim.x, "x", odin_env);',
       '  dust2::r::browser::enter(odin_env, "update", time);',
       "}"))
+})
+
+
+test_that("conditional browser using sum/min for arrays", {
+  dat <- odin_parse({
+    initial(x[]) <- 1
+    update(x[]) <- x[i] + 1
+    dim(x) <- 5
+    browser(phase = "update", when = sum(x) - min(x) > 2)
+  })
+  dat <- generate_prepare(dat)
+  expect_equal(
+    generate_dust_system_update(dat),
+    c(method_args$update,
+      "  const auto * x = state + 0;",
+      "  for (size_t i = 1; i <= shared.dim.x.size; ++i) {",
+      "    state_next[i - 1 + 0] = x[i - 1] + 1;",
+      "  }",
+      "  if (dust2::array::sum<real_type>(x, shared.dim.x) - dust2::array::min<real_type>(x, shared.dim.x) > 2) {",
+      "    auto odin_env = dust2::r::browser::create();",
+      "    dust2::r::browser::save(time, \"time\", odin_env);",
+      "    dust2::r::browser::save(x, shared.dim.x, \"x\", odin_env);",
+      "    dust2::r::browser::enter(odin_env, \"update\", time);",
+      "  }",
+      "}" ))
 })
 
 


### PR DESCRIPTION
If we try to use a reduction function on an array in a print call then we get an error (R error for `sum`/`prod`, C++ error for `min`/`max`)

e.g.
```
m <- odin2::odin({
  update(x[]) <- x[i] + i
  initial(x[]) <- 0
  dim(x) <- 5
  print("x: {sum(x)}", when = sum(x) > 20)
})
```
or
```
m <- odin2::odin({
  update(x[]) <- x[i] + i
  initial(x[]) <- 0
  dim(x) <- 5
  browser(phase = "update", when = min(x) > 4)
})
```

The reduction functions come from `dust2` rather than `monty` (where all the other maths functions are found). In the other equations this is handled by running expressions through `parse_expr_usage` (e.g. https://github.com/mrc-ide/odin2/blob/fe06e7036e66180a9fd84cca6d6fc3f400511c65/R/parse_expr.R#L244) so we use that here.

You can test these work
```
m <- odin2::odin({
  update(x[]) <- x[i] + i
  initial(x[]) <- 0
  dim(x) <- 5
  print("x: {sum(x)}", when = sum(x) > 20)
})

sys <- dust2::dust_system_create(m)
dust2::dust_system_set_state_initial(sys)
res <- dust2::dust_system_simulate(sys, seq_len(10))
```

and

```
m <- odin2::odin({
  update(x[]) <- x[i] + i
  initial(x[]) <- 0
  dim(x) <- 5
  browser(phase = "update", when = min(x) > 4)
})

sys <- dust2::dust_system_create(m)
dust2::dust_system_set_state_initial(sys)
res <- dust2::dust_system_simulate(sys, seq_len(10))
```