### PR TITLE
Include dt when using browser for discrete time models

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: odin2
 Title: Next generation odin
-Version: 0.3.45
+Version: 0.3.46
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Wes", "Hinsley", role = "aut"),

--- a/R/generate_dust.R
+++ b/R/generate_dust.R
@@ -952,6 +952,9 @@ generate_dust_browser <- function(dat, phase) {
   for (v in c("time", export)) {
     body$add(generate_dust_browser_to_env(v, dat, env))
   }
+  if (dat$time == "discrete") {
+    body$add(generate_dust_browser_to_env("dt", dat, env))
+  }
   body$add(sprintf('dust2::r::browser::enter(%s, "%s", time);', env, phase))
 
   body <- body$get()

--- a/tests/testthat/test-generate.R
+++ b/tests/testthat/test-generate.R
@@ -2396,6 +2396,7 @@ test_that("can generate browser code", {
       '    dust2::r::browser::save(a, "a", odin_env);',
       '    dust2::r::browser::save(b, "b", odin_env);',
       '    dust2::r::browser::save(x, "x", odin_env);',
+      '    dust2::r::browser::save(dt, "dt", odin_env);',
       '    dust2::r::browser::enter(odin_env, "update", time);',
       "  }",
       "}"))
@@ -2464,6 +2465,7 @@ test_that("can dereference array dimension alias in browser", {
       '  dust2::r::browser::save(internal.a.data(), shared.dim.a, "a", odin_env);',
       '  dust2::r::browser::save(internal.b.data(), shared.dim.a, "b", odin_env);',
       '  dust2::r::browser::save(x, "x", odin_env);',
+      '  dust2::r::browser::save(dt, "dt", odin_env);',
       '  dust2::r::browser::enter(odin_env, "update", time);',
       "}"))
 })
@@ -2522,6 +2524,7 @@ test_that("can generate nontrivial debug", {
       '    dust2::r::browser::save(S, "S", odin_env);',
       '    dust2::r::browser::save(I, "I", odin_env);',
       '    dust2::r::browser::save(R, "R", odin_env);',
+      '    dust2::r::browser::save(dt, "dt", odin_env);',
       '    dust2::r::browser::enter(odin_env, "update", time);',
       "  }",
       "}"))
@@ -2559,6 +2562,7 @@ test_that("browse with arrays", {
       '  dust2::r::browser::save(internal.a.data(), shared.dim.a, "a", odin_env);',
       '  dust2::r::browser::save(internal.b.data(), shared.dim.b, "b", odin_env);',
       '  dust2::r::browser::save(x, shared.dim.x, "x", odin_env);',
+      '  dust2::r::browser::save(dt, "dt", odin_env);',
       '  dust2::r::browser::enter(odin_env, "update", time);',
       "}"))
 })
@@ -2583,6 +2587,7 @@ test_that("conditional browser using sum/min for arrays", {
       "    auto odin_env = dust2::r::browser::create();",
       "    dust2::r::browser::save(time, \"time\", odin_env);",
       "    dust2::r::browser::save(x, shared.dim.x, \"x\", odin_env);",
+      "    dust2::r::browser::save(dt, \"dt\", odin_env);",
       "    dust2::r::browser::enter(odin_env, \"update\", time);",
       "  }",
       "}" ))
@@ -2995,6 +3000,7 @@ test_that("correctly use browser in system with compare", {
       '  dust2::r::browser::save(time, "time", odin_env);',
       '  dust2::r::browser::save(a, "a", odin_env);',
       '  dust2::r::browser::save(x, "x", odin_env);',
+      '  dust2::r::browser::save(dt, "dt", odin_env);',
       '  dust2::r::browser::enter(odin_env, "update", time);',
       "}"))
 })


### PR DESCRIPTION
Currently when you trigger a browser in an odin model it will let you use `time` but for discrete time models it does not let you use `dt`. It would certainly be useful to have (since you can have calculations in your odin code involving `dt`), and this is an easy fix!

Note `dt` does not exist for continuous time models, so we only want to include it for discrete time models.